### PR TITLE
Workaround for the TLSv1 bug in bootstrap

### DIFF
--- a/client/src/external/httplib2/__init__.py
+++ b/client/src/external/httplib2/__init__.py
@@ -73,11 +73,16 @@ try:
             cert_reqs = ssl.CERT_NONE
         else:
             cert_reqs = ssl.CERT_REQUIRED
-        # We should be specifying SSL version 3 or TLS v1, but the ssl module
-        # doesn't expose the necessary knobs. So we need to go with the default
-        # of SSLv23.
-        return ssl.wrap_socket(sock, keyfile=key_file, certfile=cert_file,
-                               cert_reqs=cert_reqs, ca_certs=ca_certs)
+	# Our fix for sites the only accepts SSL3
+        try:
+            # Trying SSLv3 first
+            return ssl.wrap_socket(sock, keyfile=key_file, certfile=cert_file,
+                                       cert_reqs=cert_reqs, ca_certs=ca_certs,
+                                       ssl_version=ssl.PROTOCOL_SSLv3)
+        except ssl.SSLError, e:
+            return ssl.wrap_socket(sock, keyfile=key_file, certfile=cert_file,
+                                       cert_reqs=cert_reqs, ca_certs=ca_certs,
+                                       ssl_version=ssl.PROTOCOL_SSLv23)
 except (AttributeError, ImportError):
     ssl_SSLError = None
     def _ssl_wrap_socket(sock, key_file, cert_file,

--- a/client/src/main/scripts/slipstream.bootstrap.py
+++ b/client/src/main/scripts/slipstream.bootstrap.py
@@ -20,6 +20,9 @@
 import sys
 import os
 import tarfile
+import httplib
+import socket
+import ssl
 import urllib2
 import shutil
 import subprocess
@@ -33,6 +36,17 @@ INSTALL_CMD = None
 DISTRO = None
 PIP_INSTALLED = False
 
+
+def _connect(self):
+    "Connect to a host on a given (SSL) port."
+    sock = socket.create_connection((self.host, self.port),
+                                        self.timeout, self.source_address)
+    if self._tunnel_host:
+        self.sock = sock
+        self._tunnel()
+    self.sock = ssl.wrap_socket(sock, self.key_file,
+                                self.cert_file,
+                                ssl_version=ssl.PROTOCOL_SSLv3)
 
 def _setPythonpathSlipStream():
     ss_lib = os.path.join(SLIPSTREAM_CLIENT_HOME, 'lib')
@@ -338,6 +352,8 @@ def main():
 
         msg = "=== %s bootstrap script ===" % os.path.basename(targetScript)
         print '{sep}\n{msg}\n{sep}'.format(sep=len(msg) * '=', msg=msg)
+
+        httplib.HTTPSConnection.connect = _connect
 
         setupSlipStreamAndCloudConnector(is_orchestration)
 

--- a/client/src/main/scripts/slipstream.bootstrap.py
+++ b/client/src/main/scripts/slipstream.bootstrap.py
@@ -39,8 +39,7 @@ PIP_INSTALLED = False
 
 def _connect(self):
     "Connect to a host on a given (SSL) port."
-    sock = socket.create_connection((self.host, self.port),
-                                        self.timeout, self.source_address)
+    sock = socket.create_connection((self.host, self.port))
     if self._tunnel_host:
         self.sock = sock
         self._tunnel()


### PR DESCRIPTION
Hi,

When the server is installed in CentOS 6.5, the orchestrator is not able to download the slipstream client package:

```
================================================
=== slipstream-orchestrator bootstrap script ===
================================================
Retrieving the latest version of the SlipStream from: https://slipstream.gnubila.fr/slipstreamclient.tgz
Failed contacting: https://slipstream.gnubila.fr/slipstreamclient.tgz  with error:" <urlopen error [Errno 8] _ssl.c:504: EOF occurred in violation of protocol> " retrying...
Traceback (most recent call last):
  File "/tmp/slipstream.bootstrap", line 409, in <module>
    main()
  File "/tmp/slipstream.bootstrap", line 353, in main
    publishFailureToSlipStreamRun(sys.exc_info())
  File "/tmp/slipstream.bootstrap", line 329, in publishFailureToSlipStreamRun
    _formatException(exc_info))
  File "/tmp/slipstream.bootstrap", line 377, in publish
    self._process_response(self._publish(message))
  File "/tmp/slipstream.bootstrap", line 382, in _publish
    body=message, headers=self._get_headers())
  File "/usr/lib/python2.7/httplib.py", line 958, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib/python2.7/httplib.py", line 992, in _send_request
    self.endheaders(body)
  File "/usr/lib/python2.7/httplib.py", line 954, in endheaders
    self._send_output(message_body)
  File "/usr/lib/python2.7/httplib.py", line 814, in _send_output
    self.send(msg)
  File "/usr/lib/python2.7/httplib.py", line 776, in send
    self.connect()
  File "/usr/lib/python2.7/httplib.py", line 1161, in connect
    self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file)
  File "/usr/lib/python2.7/ssl.py", line 381, in wrap_socket
    ciphers=ciphers)
  File "/usr/lib/python2.7/ssl.py", line 143, in __init__
    self.do_handshake()
  File "/usr/lib/python2.7/ssl.py", line 305, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [Errno 8] _ssl.c:504: EOF occurred in violation of protocol
```

This modification fix the problem y forcing SSLv3 protocol (as it was already done for the wget commands)

Best,
Jerome
