### PR TITLE
cookie file for client is now created in user home directory

### DIFF
--- a/client/src/main/python/slipstream/HttpClient.py
+++ b/client/src/main/python/slipstream/HttpClient.py
@@ -39,7 +39,7 @@ class HttpClient(object):
         self.username = username
         self.password = password
         self.verboseLevel = util.VERBOSE_LEVEL_NORMAL
-        self.cookieFilename = os.path.join(util.TMPDIR, 'cookie')
+        self.cookieFilename = os.path.join(os.path.expanduser('~'), '.slipstream-cookie')
         self.disableSslCertificateValidation = True
 
         if configHolder:

--- a/client/src/test/python/TestHttpClient.py
+++ b/client/src/test/python/TestHttpClient.py
@@ -57,29 +57,18 @@ class HttpClientTestCase(unittest.TestCase):
 
     def testGetSetsCookie(self):
 
-        # Use an alternate temporary directory to avoid conflicts in file
-        # permissions on /tmp/slipstream/cookie if different users run the
-        # tests on the same machine.
-        temp_dir = tempfile.mkdtemp()
-        try:
-            tempfile.tempdir = temp_dir
-
-            httpRequestMock = Mock(return_value=(httplib2.Response({'set-cookie': 'acookie'}), ''))
-
-            httpObjectMock = Mock()
-            httpObjectMock.request = httpRequestMock
-
-            mock = Mock(return_value=httpObjectMock)
-            HttpClient._getHttpObject = mock
-
-            client = HttpClient('username', 'password')
-            client.get('http://localhost:9999/url')
-
-            self.assertEqual('acookie', client.cookie)
-
-        finally:
-            tempfile.tempdir = None
-            shutil.rmtree(temp_dir)
+        httpRequestMock = Mock(return_value=(httplib2.Response({'set-cookie': 'acookie'}), ''))
+        
+        httpObjectMock = Mock()
+        httpObjectMock.request = httpRequestMock
+        
+        mock = Mock(return_value=httpObjectMock)
+        HttpClient._getHttpObject = mock
+        
+        client = HttpClient('username', 'password')
+        client.get('http://localhost:9999/url')
+        
+        self.assertEqual('acookie', client.cookie)
 
     def testGetWithCookie(self):
 


### PR DESCRIPTION
Move the cookie file to the user's home directory.  This avoids conflicts between different users on the same machine while allowing the cookie to be reused from multiple processes by the same user.

See issue #71. 
