### PR TITLE
Feature/too many requests

### DIFF
--- a/client/src/main/python/slipstream/HttpClient.py
+++ b/client/src/main/python/slipstream/HttpClient.py
@@ -200,13 +200,16 @@ class HttpClient(object):
                     if self.too_many_requests_count > 0:
                         self.too_many_requests_count -= 1
                 return resp, content
+
             except Exceptions.TooManyRequestsError:
                 sleep = min(abs(float(self.too_many_requests_count) / 10.0 * 290 + 10), 300)
                 with self.lock:
-                    self.too_many_requests_count += 1
+                    if self.too_many_requests_count < 11:
+                        self.too_many_requests_count += 1
                 util.printDetail('Too Many Requests error. Retrying in %s seconds.' % sleep)
                 time.sleep(sleep)
                 util.printDetail('Retrying...')
+
             except (httplib.HTTPException, httplib2.HttpLib2Error, socket.error,
                     Exceptions.NetworkError, Exceptions.ServerError) as ex:
                 if retry_number == 0 or max_retry == 0:

--- a/client/src/main/python/slipstream/cloudconnectors/BaseCloudConnector.py
+++ b/client/src/main/python/slipstream/cloudconnectors/BaseCloudConnector.py
@@ -309,8 +309,10 @@ class BaseCloudConnector(object):
         instance_name = node_instance.get_name()
         vm_id = self._vm_get_id(vm)
         vm_ip = self._vm_get_ip(vm)
-        self._publish_vm_id(instance_name, vm_id)
-        self._publish_vm_ip(instance_name, vm_ip)
+        if vm_id:
+            self._publish_vm_id(instance_name, vm_id)
+        if vm_ip:
+            self._publish_vm_ip(instance_name, vm_ip)
         if node_instance and vm_ip:
             self.__publish_url_ssh(vm, node_instance)
 

--- a/client/src/main/python/slipstream/exceptions/Exceptions.py
+++ b/client/src/main/python/slipstream/exceptions/Exceptions.py
@@ -40,6 +40,9 @@ class NetworkError(ServerError):
 class SecurityError(ServerError):
     pass
 
+class TooManyRequestsError(ServerError):
+    pass
+
 
 class ClientError(Exception):
     def __init__(self, arg, code=None):

--- a/client/src/main/python/slipstream/executors/node/NodeDeploymentExecutor.py
+++ b/client/src/main/python/slipstream/executors/node/NodeDeploymentExecutor.py
@@ -125,7 +125,7 @@ class NodeDeploymentExecutor(MachineExecutor):
         return self.SCALE_ACTION_TO_TARGET.get(action, None)
 
     def _execute_scale_action_target(self):
-        scale_action = self.wrapper.get_global_scale_action()
+        scale_action = self.wrapper.get_scale_action()
         if scale_action:
             # TODO: Add local scale actions (ondiskresize, etc)
             target = self._get_target_on_scale_action(scale_action)

--- a/client/src/main/python/slipstream/executors/orchestrator/OrchestratorDeploymentExecutor.py
+++ b/client/src/main/python/slipstream/executors/orchestrator/OrchestratorDeploymentExecutor.py
@@ -49,6 +49,7 @@ class OrchestratorDeploymentExecutor(MachineExecutor):
     def onExecuting(self):
         super(OrchestratorDeploymentExecutor, self).onExecuting()
         self._complete_state_for_failed_node_instances()
+        self.wrapper.check_scale_state_consistency()
 
     @override
     def onSendingReports(self):

--- a/client/src/main/python/slipstream/wrappers/BaseWrapper.py
+++ b/client/src/main/python/slipstream/wrappers/BaseWrapper.py
@@ -265,6 +265,19 @@ class BaseWrapper(object):
         state = self._get_global_scale_state()
         return self._state_to_action(state)
 
+    def get_scale_action(self):
+        state = self.get_scale_state()
+        return self._state_to_action(state)
+
+    def check_scale_state_consistency(self):
+        states_node_instances = self._get_effective_scale_states()
+        states_node_instances.pop(self.SCALE_STATE_REMOVED, None)
+
+        if len(states_node_instances) > 1:
+            msg = "Inconsistent scaling situation. Single scaling action allowed," \
+                  " found: %s" % states_node_instances
+            raise Exceptions.ExecutionException(msg)
+
     def get_scaling_node_and_instance_names(self):
         '''Return name of the node and the corresponding instances that are
         currently being scaled.

--- a/client/src/main/python/slipstream/wrappers/BaseWrapper.py
+++ b/client/src/main/python/slipstream/wrappers/BaseWrapper.py
@@ -27,6 +27,7 @@ from slipstream.exceptions import Exceptions
 class NodeInfoPublisher(SlipStreamHttpClient):
     def __init__(self, configHolder):
         super(NodeInfoPublisher, self).__init__(configHolder)
+        self.set_http_max_retries(-5)
 
     def publish(self, nodename, vm_id, vm_ip):
         self.publish_instanceid(nodename, vm_id)


### PR DESCRIPTION
- Added support for "429 - Too many requests" with exponential backoff.
- The check for the scale state consistensy is now made only on orchestrators to prevent `n**2` requests to the SS server with n=`number of VMs in the Run`. Now the number of requests needed for this check is `n*c` with c=`number of Clouds involved in the Run`.
- The check for the scale state consistensy now doesn't fail if the orchestrator removed some failed nodes.
