### PR TITLE
Fixed 'Windows machines send an abort flag when they are shutdown'.

### DIFF
--- a/client/src/main/python/slipstream/executors/MachineExecutor.py
+++ b/client/src/main/python/slipstream/executors/MachineExecutor.py
@@ -106,7 +106,10 @@ class MachineExecutor(object):
 
     @staticmethod
     def _sleep(seconds):
-        time.sleep(seconds)
+        try:
+            time.sleep(seconds)
+        except IOError:
+            pass
 
     def _get_sleep_time(self, state):
         if not self._is_mutable() and self._in_ready_and_no_need_to_stop_images(state):


### PR DESCRIPTION
Connected to slipstream/SlipStreamServer#319