### PR TITLE
Fix: deployment may randomly and silently fail on Windows

### DIFF
--- a/client/src/main/python/slipstream/executors/node/NodeDeploymentExecutor.py
+++ b/client/src/main/python/slipstream/executors/node/NodeDeploymentExecutor.py
@@ -254,8 +254,9 @@ class NodeDeploymentExecutor(MachineExecutor):
         return process.returncode
 
     def _add_ssh_pubkey(self, login_user):
-        util.printStep('Adding the public keys')
-        append_ssh_pubkey_to_authorized_keys(self._get_user_ssh_pubkey(), login_user)
+        if not util.is_windows():
+            util.printStep('Adding the public keys')
+            append_ssh_pubkey_to_authorized_keys(self._get_user_ssh_pubkey(), login_user)
 
     def _get_user_ssh_pubkey(self):
         return self.wrapper.get_user_ssh_pubkey()

--- a/client/src/main/python/slipstream/util.py
+++ b/client/src/main/python/slipstream/util.py
@@ -28,7 +28,10 @@ import getpass
 import urllib2
 import uuid as uuidModule
 import warnings
-import pwd
+
+if sys.platform != 'win32':
+    import pwd
+
 from itertools import chain
 from ConfigParser import SafeConfigParser
 


### PR DESCRIPTION
Don't import 'pwd' in Windows.
Don't add public keys in Windows.

Connected to #111