### PR TITLE
Use the new system parameter 'native-contextualization', if available, to choose the kind of contextualization

### DIFF
--- a/client/src/main/python/slipstream/NodeDecorator.py
+++ b/client/src/main/python/slipstream/NodeDecorator.py
@@ -75,6 +75,7 @@ class NodeDecorator(object):
     CLOUDSERVICE_KEY = 'cloudservice'
     SECURITY_GROUPS_KEY = 'security.groups'
     MAX_PROVISIONING_FAILURES_KEY = 'max-provisioning-failures'
+    NATIVE_CONTEXTUALIZATION_KEY = 'native-contextualization'
 
     urlIgnoreAbortAttributeFragment = '?ignoreabort=true'
 

--- a/client/src/main/python/slipstream/cloudconnectors/BaseCloudConnector.py
+++ b/client/src/main/python/slipstream/cloudconnectors/BaseCloudConnector.py
@@ -279,6 +279,23 @@ class BaseCloudConnector(object):
     def has_capability(self, capability):
         return capability in self.__capabilities
 
+    def __set_contextualization_capabilities(self, user_info):
+        native_contextualization = user_info.get_cloud(NodeDecorator.NATIVE_CONTEXTUALIZATION_KEY, None)
+        if native_contextualization:
+            try:
+                self.__capabilities.remove(self.CAPABILITY_CONTEXTUALIZATION)
+                self.__capabilities.remove(self.CAPABILITY_WINDOWS_CONTEXTUALIZATION)
+            except ValueError:
+                pass
+
+            if native_contextualization == 'always':
+                self.__capabilities.append(self.CAPABILITY_CONTEXTUALIZATION)
+                self.__capabilities.append(self.CAPABILITY_WINDOWS_CONTEXTUALIZATION)
+            elif native_contextualization == 'linux only':
+                self.__capabilities.append(self.CAPABILITY_CONTEXTUALIZATION)
+            elif native_contextualization == 'windows only':
+                self.__capabilities.append(self.CAPABILITY_WINDOWS_CONTEXTUALIZATION)
+
     def is_build_image(self):
         return self.run_category == NodeDecorator.IMAGE
 
@@ -317,6 +334,7 @@ class BaseCloudConnector(object):
 
     def start_nodes_and_clients(self, user_info, nodes_instances, init_extra_kwargs={}):
         self._initialization(user_info, **init_extra_kwargs)
+        self.__set_contextualization_capabilities(user_info)
         try:
             self.__start_nodes_instantiation_tasks_wait_finished(user_info,
                                                                  nodes_instances)
@@ -734,7 +752,7 @@ class BaseCloudConnector(object):
 
         command = 'mkdir %(reports)s\n'
         command += 'If Not Exist "C:\\Python27\\python.exe" ( '
-        command += '  powershell -Command "$wc = New-Object System.Net.WebClient; $wc.DownloadFile(\'http://www.python.org/ftp/python/2.7.4/python-2.7.4.msi\', $env:temp+\'\\python.msi\')"\n'
+        command += '  powershell -Command "$wc = New-Object System.Net.WebClient; $wc.DownloadFile(\'https://www.python.org/ftp/python/2.7.10/python-2.7.10.amd64.msi\', $env:temp+\'\\python.msi\')"\n'
         command += '  start /wait msiexec /i %%TMP%%\\python.msi /qn /quiet /norestart /log log.txt TARGETDIR=C:\\Python27\\ ALLUSERS=1 '
         command += ')\n'
         command += 'setx path "%%path%%;C:\\Python27;C:\\opt\\slipstream\\client\\bin;C:\\opt\\slipstream\\client\\sbin" /M\n'

--- a/client/src/main/python/slipstream/cloudconnectors/BaseCloudConnector.py
+++ b/client/src/main/python/slipstream/cloudconnectors/BaseCloudConnector.py
@@ -291,9 +291,9 @@ class BaseCloudConnector(object):
             if native_contextualization == 'always':
                 self.__capabilities.append(self.CAPABILITY_CONTEXTUALIZATION)
                 self.__capabilities.append(self.CAPABILITY_WINDOWS_CONTEXTUALIZATION)
-            elif native_contextualization == 'linux only':
+            elif native_contextualization == 'linux-only':
                 self.__capabilities.append(self.CAPABILITY_CONTEXTUALIZATION)
-            elif native_contextualization == 'windows only':
+            elif native_contextualization == 'windows-only':
                 self.__capabilities.append(self.CAPABILITY_WINDOWS_CONTEXTUALIZATION)
 
     def is_build_image(self):

--- a/client/src/main/python/slipstream/command/RunInstancesCommand.py
+++ b/client/src/main/python/slipstream/command/RunInstancesCommand.py
@@ -75,10 +75,21 @@ class RunInstancesCommand(CloudClientCommand):
                           help='Username of the user to use to contextualize the instance',
                           default='', metavar='USER')
 
+        parser.add_option('--' + NodeDecorator.NATIVE_CONTEXTUALIZATION_KEY, dest=NodeDecorator.NATIVE_CONTEXTUALIZATION_KEY,
+                          help='When SlipStream should use the native Cloud contextualization mechanisme (instead of SSH/WinRM)\nPossible values: never|always|linux only|windows only',
+                          default='', metavar='NATIV_CONTEXTUALIZATION')
+
     def _get_command_mandatory_options(self):
         return [self.IMAGE_ID_KEY,
                 self.PLATFORM_KEY,
                 self.NETWORK_TYPE]
+
+    def _get_command_specific_user_cloud_params(self):
+        native_contextualization = self.get_option(NodeDecorator.NATIVE_CONTEXTUALIZATION_KEY)
+        if native_contextualization:
+            return {NodeDecorator.NATIVE_CONTEXTUALIZATION_KEY: native_contextualization}
+        else:
+            return {}
 
     def _get_default_timeout(self):
         return self.DEFAULT_TIMEOUT

--- a/client/src/main/python/slipstream/command/RunInstancesCommand.py
+++ b/client/src/main/python/slipstream/command/RunInstancesCommand.py
@@ -76,7 +76,7 @@ class RunInstancesCommand(CloudClientCommand):
                           default='', metavar='USER')
 
         parser.add_option('--' + NodeDecorator.NATIVE_CONTEXTUALIZATION_KEY, dest=NodeDecorator.NATIVE_CONTEXTUALIZATION_KEY,
-                          help='When SlipStream should use the native Cloud contextualization mechanisme (instead of SSH/WinRM)\nPossible values: never|always|linux only|windows only',
+                          help='When SlipStream should use the native Cloud contextualization (instead of SSH/WinRM)\nPossible values: never|always|linux-only|windows-only',
                           default='', metavar='NATIVE_CONTEXTUALIZATION')
 
     def _get_command_mandatory_options(self):

--- a/client/src/main/python/slipstream/command/RunInstancesCommand.py
+++ b/client/src/main/python/slipstream/command/RunInstancesCommand.py
@@ -77,7 +77,7 @@ class RunInstancesCommand(CloudClientCommand):
 
         parser.add_option('--' + NodeDecorator.NATIVE_CONTEXTUALIZATION_KEY, dest=NodeDecorator.NATIVE_CONTEXTUALIZATION_KEY,
                           help='When SlipStream should use the native Cloud contextualization mechanisme (instead of SSH/WinRM)\nPossible values: never|always|linux only|windows only',
-                          default='', metavar='NATIV_CONTEXTUALIZATION')
+                          default='', metavar='NATIVE_CONTEXTUALIZATION')
 
     def _get_command_mandatory_options(self):
         return [self.IMAGE_ID_KEY,


### PR DESCRIPTION
 Allow SlipStream administrators to choose the kind of contextualization to use for Linux and Windows machines.
Updated the version of Python used on Windows to v2.7.10.

Connected to slipstream/SlipStream#69

Related PR:
- slipstream/SlipStreamServer#373
- slipstream/SlipStreamConnectors#33 
