### PR TITLE
Request global scale state instead of local one, when evaluating the need to run OnVmAdd/Remove targets

### DIFF
--- a/client/src/main/python/slipstream/executors/node/NodeDeploymentExecutor.py
+++ b/client/src/main/python/slipstream/executors/node/NodeDeploymentExecutor.py
@@ -145,7 +145,7 @@ class NodeDeploymentExecutor(MachineExecutor):
         return self.SCALE_ACTION_TO_TARGET.get(action, None)
 
     def _execute_scale_action_target(self):
-        scale_action = self.wrapper.get_scale_action()
+        scale_action = self.wrapper.get_global_scale_action()
         if scale_action:
             # TODO: Add local scale actions (ondiskresize, etc)
             target = self._get_target_on_scale_action(scale_action)

--- a/client/src/test/python/TestNodeDeploymentExecutor.py
+++ b/client/src/test/python/TestNodeDeploymentExecutor.py
@@ -62,3 +62,12 @@ class TestNodeDeploymentExecutor(TestCloudConnectorsBase):
                           *(target, {}, True))
         assert 1 == nde.wrapper.fail.call_count
 
+    def test_execute_scale_action_target_gets_global_scale_action(self):
+        wrapper = Mock()
+        wrapper.get_scale_action = Mock(return_value=None)
+        wrapper.get_global_scale_action = Mock(return_value=None)
+        nde = NodeDeploymentExecutor(wrapper, configHolder=self.ch)
+        nde._execute_scale_action_target()
+        assert True == nde.wrapper.get_global_scale_action.called
+        assert False == nde.wrapper.get_scale_action.called
+


### PR DESCRIPTION
Connected to #126 