### PR TITLE
Bugfix and improvements of ss-module-download:

### DIFF
--- a/client/src/main/python/ss-module-download.py
+++ b/client/src/main/python/ss-module-download.py
@@ -98,10 +98,10 @@ class MainProgram(CommandBase):
             parameters = root.find('parameters')
             if parameters is not None:
                 for cloud_name in cloud_names.findall('*'):
+                    # The following XPath query doesn't work with Python < 2.7
                     cloud_parameters = parameters.findall("./entry/parameter[@category='%s'].." % cloud_name.text)
                     if cloud_parameters is not None:
                         for cloud_parameter in cloud_parameters:
-                            #ET.dump(cloud_parameter)
                             parameters.remove(cloud_parameter)
                         cloud_names.remove(cloud_name)
 
@@ -162,6 +162,11 @@ class MainProgram(CommandBase):
         return children
 
     def doWork(self):
+
+        if self.options.remove_clouds and sys.version_info[0:3] < (2, 7, 0):
+            print('Error: The use of "--remove-cloud-specific" require Python >= 2.7', file=sys.stderr)
+            sys.exit(1)
+
         client = HttpClient(self.options.username, self.options.password)
         client.verboseLevel = self.verboseLevel
 

--- a/client/src/main/python/ss-module-download.py
+++ b/client/src/main/python/ss-module-download.py
@@ -19,6 +19,7 @@
 from __future__ import print_function
 
 import os
+import os.path
 import sys
 import xml.etree.ElementTree as ET
 
@@ -35,7 +36,6 @@ class MainProgram(CommandBase):
         self.password = None
         self.cookie = None
         self.endpoint = None
-        self.purgImageIds = False
         super(MainProgram, self).__init__(argv)
 
     def parse(self):
@@ -48,8 +48,20 @@ class MainProgram(CommandBase):
         self.add_authentication_options()
         self.addEndpointOption()        
 
-        self.parser.add_option('--purge-image-ids', dest='purgImageIds',
-                               help='Remove cloud image ids before saving',
+        self.parser.add_option('--remove-cloud-specific', dest='remove_clouds',
+                               help='Remove all cloud specific elements (image ids, cloud parameters, ...)',
+                               default=False, action='store_true')
+
+        self.parser.add_option('--remove-group-members', dest='remove_group_members',
+                               help='Remove members of the group in the authorizations',
+                               default=False, action='store_true')
+
+        self.parser.add_option('--reset-commit-message', dest='reset_commit_message',
+                               help='Replace the commit message by "Initial version of this module"',
+                               default=False, action='store_true')
+
+        self.parser.add_option('--flat', dest='flat_export',
+                               help='Download without creating subdirectories',
                                default=False, action='store_true')
 
         self.options, self.args = self.parser.parse_args()
@@ -72,15 +84,52 @@ class MainProgram(CommandBase):
             for run in runs.findall('*'):
                 runs.remove(run)
 
-    def _removeCloudImageIdentifiers(self, root):
-        """Remove the cloudImageIdentifiers element from
-           the given document.  These identifiers are not
-           portable between SlipStream deployments."""
+    def _remove_clouds(self, root):
+        """Remove the cloudImageIdentifiers, cloudNames and cloud specific parameters element from the given document.
+           These elements are not portable between SlipStream deployments."""
 
         ids = root.find('cloudImageIdentifiers')
         if ids is not None:
             for id in ids.findall('*'):
                 ids.remove(id)
+
+        cloud_names = root.find('cloudNames')
+        if cloud_names is not None:
+            parameters = root.find('parameters')
+            if parameters is not None:
+                for cloud_name in cloud_names.findall('*'):
+                    cloud_parameters = parameters.findall("./entry/parameter[@category='%s'].." % cloud_name.text)
+                    if cloud_parameters is not None:
+                        for cloud_parameter in cloud_parameters:
+                            #ET.dump(cloud_parameter)
+                            parameters.remove(cloud_parameter)
+                        cloud_names.remove(cloud_name)
+
+    def _remove_group_members(self, root):
+        authz = root.find('authz')
+        if authz is None:
+            return
+
+        group_members = authz.find('groupMembers')
+        if group_members is None:
+            return
+
+        for group_member in group_members.findall('*'):
+            group_members.remove(group_member)
+
+    def _reset_commit_message(self, root):
+        authz = root.find('authz')
+
+        commit = root.find('commit')
+        if commit is None:
+            return
+
+        commit.attrib['author'] = (authz is not None) and authz.attrib.get('owner', 'super') or 'super'
+
+        comment = commit.find('comment')
+        if comment is None:
+            return
+        comment.text = 'Initial version of this module'
 
     def _retrieveModuleAsXml(self, client, module):
         uri = util.MODULE_RESOURCE_PATH
@@ -93,7 +142,16 @@ class MainProgram(CommandBase):
         return ET.fromstring(xml)
 
     def _writeModuleAsXml(self, root_element, module):
-        ET.ElementTree(root_element).write('%s.xml' % module.replace('/', '_'))
+        if self.options.flat_export:
+            module = module.replace('/', '_')
+        else:
+            if root_element.attrib.get('category', '').lower().strip() == 'project':
+                module = os.path.join(module, os.path.basename(module))
+            try:
+                os.makedirs(os.path.dirname(module), 0775)
+            except OSError as e:
+                pass
+        ET.ElementTree(root_element).write('%s.xml' % module)
 
     def _getModuleChildren(self, module, root_element):
         children = []
@@ -115,8 +173,12 @@ class MainProgram(CommandBase):
 
             root = self._retrieveModuleAsXml(client, module)
             self._removeRuns(root)
-            if self.purgImageIds:
-                self._removeCloudImageIdentifiers(root)
+            if self.options.remove_clouds:
+                self._remove_clouds(root)
+            if self.options.remove_group_members:
+                self._remove_group_members(root)
+            if self.options.reset_commit_message:
+                self._reset_commit_message(root)
             self._writeModuleAsXml(root, module)
 
             for child in self._getModuleChildren(module, root):


### PR DESCRIPTION
- Fixed a bug where --purge-image-ids wasn't taken into account.
- Updated `--purge-image-ids` to `--remove-cloud-specific`
- Added `--remove-group-members`
- Added `--reset-commit-message`
- Added `--flat` (previously it was the default)
  Now a directory structure will be created by default

The new version of `ss-module-download` was used to fetch [`examples`](https://slipstream.sixsq.com/module/examples) into the following directory (with `--flat`) : [client/src/main/resources/doc/](https://github.com/slipstream/SlipStreamClient/tree/master/client/src/main/resources/doc)
It was also used (without `--flat`) to populate the new repository [slipstream/apps](https://github.com/slipstream/apps)  with the [`apps`](https://slipstream.sixsq.com/module/apps).

The `README` in these two places already makes use of the new features of `ss-module-download` provided by this PR. So if during the review the behaviour of this command is changed, we will have to update these `README`.