### PR TITLE
update python packaging for CentOS 7

### DIFF
--- a/rpm/pom.xml
+++ b/rpm/pom.xml
@@ -41,6 +41,40 @@
 			  </arguments>
 			</configuration>
 		      </execution>
+
+		      <execution>
+			<id>pyc</id>
+			<goals>
+			  <goal>exec</goal>
+			</goals>
+			<phase>compile</phase>
+			<configuration>
+			  <executable>python</executable>
+			  <arguments>
+			    <argument>-m</argument>
+			    <argument>compileall</argument>
+			    <argument>${project.build.directory}/client</argument>
+			  </arguments>
+			</configuration>
+		      </execution>
+		      
+		      <execution>
+			<id>pyo</id>
+			<goals>
+			  <goal>exec</goal>
+			</goals>
+			<phase>compile</phase>
+			<configuration>
+			  <executable>python</executable>
+			  <arguments>
+			    <argument>-O</argument>
+			    <argument>-m</argument>
+			    <argument>compileall</argument>
+			    <argument>${project.build.directory}/client</argument>
+			  </arguments>
+			</configuration>
+		      </execution>
+		      
 		    </executions>
 		  </plugin>
 
@@ -99,7 +133,9 @@
 				<configuration>
 					<classifier>${package.os}</classifier>
 					<release>${BUILD_NUMBER}.${package.os}</release>
-					<summary>SlipStream Client API and CLI</summary>
+					<summary>SlipStream Client API and CLI
+%include %{_rpmconfigdir}/macros.python
+					</summary>
 					<name>slipstream-client${slipstream.edition}</name>
 					<group>Applications/Engineering</group>
 					<vendor>SixSq</vendor>
@@ -158,7 +194,7 @@
 						</mapping>
 
 						<mapping>
-							<directory>/usr/lib/python2.6/site-packages</directory>
+							<directory>%{py_sitedir}</directory>
 							<filemode>644</filemode>
 							<username>slipstream</username>
 							<groupname>slipstream</groupname>
@@ -170,9 +206,6 @@
 									  <include>slipstream/**/*</include>
 									  <include>winrm/**/*</include>
 									</includes>
-									<excludes>
-										<exclude>**/*.pyc</exclude>
-									</excludes>
 								</source>
 							</sources>
 						</mapping>
@@ -251,27 +284,28 @@
 
 					</mappings>
 
-<prepareScriptlet>
-<script>
-# Turn off the brp-python-bytecompile script                                                        
-%global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
-</script>
- </prepareScriptlet>
+<installScriptlet>
+  <script>
+mkdir -p $RPM_BUILD_ROOT/%{py_sitedir}
+mv $RPM_BUILD_ROOT/%%py_sitedir/* $RPM_BUILD_ROOT/%{py_sitedir}
+  </script>
+</installScriptlet>
 
-         <preinstallScriptlet>
-             <script>
+<preinstallScriptlet>
+  <script>
 /bin/rm -f /usr/bin/cloudstack-*
 /bin/rm -f /usr/bin/openstack-*
-             </script>
-         </preinstallScriptlet>
+  </script>
+</preinstallScriptlet>
 
-          <postinstallScriptlet>
-            <!-- fixing a bug in client -->
-            <script>
+<postinstallScriptlet>
+
+  <!-- fixing a bug in client -->
+  <script>
 /bin/touch /usr/bin/slipstream.client.conf
 /bin/touch /opt/slipstream/connectors/bin/slipstream.client.conf
-            </script>
-          </postinstallScriptlet>
+  </script>
+</postinstallScriptlet>
 
 				</configuration>
 				<executions>


### PR DESCRIPTION
Remove hardcoding of python installation path to allow packaging and installation on CentOS 7 as well as CentOS 6. 

Connected to slipstream/SlipStream#72.