### PR TITLE
Fixes processing of not aliased connector name in /configuration resource from ss-config-dump

### DIFF
--- a/client/src/main/python/slipstream/resources/configuration.py
+++ b/client/src/main/python/slipstream/resources/configuration.py
@@ -1,0 +1,52 @@
+"""
+ SlipStream Client
+ =====
+ Copyright (C) 2015 SixSq Sarl (sixsq.com)
+ =====
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from slipstream.util import SERVER_CONFIGURATION_BASICS_CATEGORY
+from slipstream.util import SERVER_CONFIGURATION_CONNECTOR_CLASSES_KEY
+
+
+def get_cloud_connector_classes(config):
+    """
+    :param config: representation of the configuration
+    :type config: dict
+    :rtype: dict
+    """
+    cloud_connector_classes = {}
+    for p in config.get(SERVER_CONFIGURATION_BASICS_CATEGORY, []):
+        if len(p) == 2:
+            k, v = p
+            if k == SERVER_CONFIGURATION_CONNECTOR_CLASSES_KEY:
+                cloud_connector_classes = _connector_classes_str_to_dict(v)
+                break
+    return cloud_connector_classes
+
+def _connector_classes_str_to_dict(classes_conf_str):
+    """
+    Input: 'foo:bar, baz'
+    Result: {'foo': 'bar', 'baz': 'baz'}
+    """
+    if len(classes_conf_str) == 0:
+        return {}
+    classes_conf_dict = {}
+    for cc in classes_conf_str.split(','):
+        cc_t = cc.strip().split(':')
+        if len(cc_t) == 1:
+           classes_conf_dict[cc_t[0]] = cc_t[0]
+        else:
+           classes_conf_dict[cc_t[0]] = cc_t[1]
+    return classes_conf_dict

--- a/client/src/main/python/ss-config-dump.py
+++ b/client/src/main/python/ss-config-dump.py
@@ -38,7 +38,7 @@ from slipstream.util import SERVER_CONFIGURATION_CONNECTOR_CLASSES_KEY
 class MainProgram(CommandBase):
 
     NO_CONNECTOR_CLASS_MAPPING_MSG = '<CONNECTOR IS INACTIVE. CONNECTOR CLASS NOT KNOWN!>'
-    HOSTNAME_MASK = '<CHANGE_HOSTSNAME>'
+    HOSTNAME_MASK = '<CHANGE_HOSTNAME>'
 
     def __init__(self, argv=None):
         self._categories = []

--- a/client/src/main/python/ss-config-dump.py
+++ b/client/src/main/python/ss-config-dump.py
@@ -34,6 +34,8 @@ from slipstream.util import SERVER_CONFIGURATION_DEFAULT_CATEGORIES
 from slipstream.util import SERVER_CONFIGURATION_BASICS_CATEGORY
 from slipstream.util import SERVER_CONFIGURATION_CONNECTOR_CLASSES_KEY
 
+from slipstream.resources.configuration import get_cloud_connector_classes
+
 
 class MainProgram(CommandBase):
 
@@ -177,7 +179,7 @@ Different sections (categories) of the configuration can be extracted with --cat
                 "inactive connectors." % category)
 
     def _config_generate_for_categories(self, config):
-        cloud_connector_classes = self._get_cloud_connector_classes(config)
+        cloud_connector_classes = get_cloud_connector_classes(config)
         config_new= {}
         for category, params in config.iteritems():
             not_in_requested_category_set = self._categories and (category not in self._categories)
@@ -204,20 +206,6 @@ Different sections (categories) of the configuration can be extracted with --cat
 
     def _print_warning(self, msg):
         print('# WARNING: %s' % msg)
-
-    @staticmethod
-    def _get_cloud_connector_classes(config):
-        """
-        :param config: ElementTree representation of the configuration
-        :type config: ElementTree
-        :rtype: dict
-        """
-        cloud_connector_classes = {}
-        for p in config.get(SERVER_CONFIGURATION_BASICS_CATEGORY):
-            k, v = p
-            if k == SERVER_CONFIGURATION_CONNECTOR_CLASSES_KEY:
-                cloud_connector_classes = dict(map(lambda x: x.strip().split(':'), v.split(',')))
-        return cloud_connector_classes
 
     @staticmethod
     def _print_categories(config):

--- a/client/src/test/python/TestResourcesConfiguration.py
+++ b/client/src/test/python/TestResourcesConfiguration.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+"""
+ SlipStream Client
+ =====
+ Copyright (C) 2015 SixSq Sarl (sixsq.com)
+ =====
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+import unittest
+
+from slipstream.resources.configuration import _connector_classes_str_to_dict
+from slipstream.resources.configuration import get_cloud_connector_classes
+from slipstream.util import SERVER_CONFIGURATION_BASICS_CATEGORY
+from slipstream.util import SERVER_CONFIGURATION_CONNECTOR_CLASSES_KEY
+
+
+class TestConfigurationResource(unittest.TestCase):
+
+    def test_connector_classes_str_to_dict(self):
+        assert {} == _connector_classes_str_to_dict('')
+        assert {'foo': 'foo'} == _connector_classes_str_to_dict('foo')
+        assert {'foo': 'bar'} == _connector_classes_str_to_dict('foo:bar')
+
+        res = _connector_classes_str_to_dict('foo:bar, baz')
+        unmatched_items = set([('foo', 'bar'), ('baz', 'baz')]) ^ set(res.items())
+        assert 0 == len(unmatched_items)
+
+    def test_get_cloud_connector_classes_from_basics_category(self):
+        assert {} == get_cloud_connector_classes({})
+        assert {} == get_cloud_connector_classes({'foo': 'bar'})
+        assert {} == get_cloud_connector_classes({SERVER_CONFIGURATION_BASICS_CATEGORY: []})
+        assert {} == get_cloud_connector_classes({SERVER_CONFIGURATION_BASICS_CATEGORY: [(),]})
+        assert {} == get_cloud_connector_classes({SERVER_CONFIGURATION_BASICS_CATEGORY: [('',''),]})
+
+        conf = {SERVER_CONFIGURATION_BASICS_CATEGORY: [(SERVER_CONFIGURATION_CONNECTOR_CLASSES_KEY, ''),]}
+        assert {} == get_cloud_connector_classes(conf)
+
+        conf = {SERVER_CONFIGURATION_BASICS_CATEGORY: [(SERVER_CONFIGURATION_CONNECTOR_CLASSES_KEY, 'foo'),]}
+        assert {'foo': 'foo'} == get_cloud_connector_classes(conf)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Connected to #171 

Note:  Introduced `slipstream.resources` package with `configuration` module in it.  Later `configuration` will contain more code extracted from `ss-config-dump`.  Will create a new issue for that after this one gets merged.