### PR TITLE
If `at` command is not present on the target host attempt to use `nohup`

### DIFF
--- a/client/src/main/python/slipstream/utils/ssh.py
+++ b/client/src/main/python/slipstream/utils/ssh.py
@@ -394,6 +394,7 @@ def remoteRunScript(user, host, script, sshKey=None, password='', nohup=False):
 def remoteRunScriptNohup(user, host, script, sshKey=None, password=''):
     return remoteRunScript(user, host, script, sshKey=sshKey, password=password, nohup=True)
 
+
 def remoteRunCommand(user, host, command, sshKey=None, password='', nohup=False):
     nohup_cmd = (nohup is True) and 'at now -f %s' or '%s'
     sudo = (user != 'root') and 'sudo' or ''
@@ -407,8 +408,12 @@ def remoteRunCommand(user, host, command, sshKey=None, password='', nohup=False)
             nohup_cmd = rc == 0 and 'nohup %s' or '%s'
             cmd = ('%s %s >/dev/null 2>&1 </dev/null &' % (sudo, nohup_cmd % command)).strip()
             rc, stderr = sshCmdWithStderr(cmd, host, user=user, sshKey=sshKey, password=password)
+            if rc != 0:
+                raise Exceptions.ExecutionException("An error occurred while executing the command: %s\n%s." %
+                                                    (command, stderr))
         else:
-            raise Exceptions.ExecutionException("An error occurred while executing the command: %s\n%s." % (command,stderr))
+            raise Exceptions.ExecutionException("An error occurred while executing the command: %s\n%s." %
+                                                (command, stderr))
     else:
         # Check stderr as atd may not be running, though return code was 0.
         # Starting atd service will start the command.

--- a/client/src/main/python/slipstream/utils/ssh.py
+++ b/client/src/main/python/slipstream/utils/ssh.py
@@ -428,6 +428,6 @@ def _remote_command_exists(command, user, host, sshKey=None, password=''):
 
 
 def remote_start_service(service, user, host, sshKey=None, password=''):
-    command = 'service %(s)s start || initctl %(s)s atd || systemctl %(s)s atd || /etc/init.d/%(s)s start' % \
+    command = 'service %(s)s start || initctl start %(s)s || systemctl start %(s)s || /etc/init.d/%(s)s start' % \
               {'s': service}
     remoteRunCommand(user, host, command, sshKey, password)

--- a/client/src/main/python/slipstream/utils/ssh.py
+++ b/client/src/main/python/slipstream/utils/ssh.py
@@ -417,7 +417,7 @@ def remoteRunCommand(user, host, command, sshKey=None, password='', nohup=False)
         # Check stderr as atd may not be running, though return code was 0.
         # Starting atd service will start the command.
         if re.search('.*No atd running\?', stderr, re.MULTILINE):
-            remoteRunCommand(user, host, 'service atd start', sshKey, password)
+            remote_start_service('atd', user, host, sshKey, password)
 
     return rc, stderr
 
@@ -426,3 +426,8 @@ def _remote_command_exists(command, user, host, sshKey=None, password=''):
     rc, stderr = sshCmdWithStderr('which %s' % command, host, user, sshKey, password)
     return rc == 0
 
+
+def remote_start_service(service, user, host, sshKey=None, password=''):
+    command = 'service %(s)s start || initctl %(s)s atd || systemctl %(s)s atd || /etc/init.d/%(s)s start' % \
+              {'s': service}
+    remoteRunCommand(user, host, command, sshKey, password)


### PR DESCRIPTION
If `at` command is not present on the target host attempt to use `nohup` (if present), or default to just going to background.  In the latter case it's better if the target script(/command) traps `HUP` signal in the case the ssh connection was requesting controlling terminal.  In this case, the script will receive the signal from the shell that is going to be terminated by the logout, and effectively ignores it.

Connected to #193 