### PR TITLE
Fix: updated call to get_node_instances_in_scale_stateI() with the new signature

### DIFF
--- a/client/src/main/python/slipstream/executors/orchestrator/OrchestratorDeploymentExecutor.py
+++ b/client/src/main/python/slipstream/executors/orchestrator/OrchestratorDeploymentExecutor.py
@@ -87,7 +87,7 @@ class OrchestratorDeploymentExecutor(MachineExecutor):
     def _wait_pre_scale_done_if_horizontal_scale_down(self):
         if self._is_horizontal_scale_down():
             node_instances = self.wrapper.get_node_instances_in_scale_state(
-                self.wrapper.SCALE_STATE_REMOVING, self.wrapper._get_cloud_service_name())
+                self.wrapper.SCALE_STATE_REMOVING)
             self.wrapper._wait_pre_scale_done(node_instances.values())
 
     @staticmethod


### PR DESCRIPTION
This was breaking scaling down action.

Connected to #200 