### PR TITLE
Add support for systemd when bootstrapping machine executor

### DIFF
--- a/client/src/main/scripts/etc/slipstream-node.service
+++ b/client/src/main/scripts/etc/slipstream-node.service
@@ -6,7 +6,6 @@ After=syslog.target
 EnvironmentFile=-/etc/default/slipstream-node
 ExecStart=/opt/slipstream/client/sbin/slipstream-node ${DAEMON_ARGS} start
 ExecStop=/opt/slipstream/client/sbin/slipstream-node stop
-Type=forking
 PIDFile=/var/run/slipstream-node.pid
 
 [Install]

--- a/client/src/main/scripts/etc/slipstream-node.service
+++ b/client/src/main/scripts/etc/slipstream-node.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SlipStream Node Executor
+After=syslog.target
+
+[Service]
+EnvironmentFile=-/etc/default/slipstream-node
+ExecStart=/opt/slipstream/client/sbin/slipstream-node ${DAEMON_ARGS} start
+ExecStop=/opt/slipstream/client/sbin/slipstream-node stop
+Type=forking
+PIDFile=/var/run/slipstream-node.pid
+
+[Install]
+WantedBy=multi-user.target

--- a/client/src/main/scripts/etc/slipstream-orchestrator.service
+++ b/client/src/main/scripts/etc/slipstream-orchestrator.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SlipStream Orchestrator Executor
+After=syslog.target
+
+[Service]
+EnvironmentFile=-/etc/default/slipstream-orchestrator
+ExecStart=/opt/slipstream/client/sbin/slipstream-orchestrator ${DAEMON_ARGS} start
+ExecStop=/opt/slipstream/client/sbin/slipstream-orchestrator stop
+Type=forking
+PIDFile=/var/run/slipstream-orchestrator.pid
+
+[Install]
+WantedBy=multi-user.target

--- a/client/src/main/scripts/etc/slipstream-orchestrator.service
+++ b/client/src/main/scripts/etc/slipstream-orchestrator.service
@@ -6,7 +6,6 @@ After=syslog.target
 EnvironmentFile=-/etc/default/slipstream-orchestrator
 ExecStart=/opt/slipstream/client/sbin/slipstream-orchestrator ${DAEMON_ARGS} start
 ExecStop=/opt/slipstream/client/sbin/slipstream-orchestrator stop
-Type=forking
 PIDFile=/var/run/slipstream-orchestrator.pid
 
 [Install]

--- a/client/src/main/scripts/slipstream.bootstrap.py
+++ b/client/src/main/scripts/slipstream.bootstrap.py
@@ -43,18 +43,18 @@ MACHINE_EXECUTOR_NAMES = ['node', 'orchestrator']
 INSTALL_CMD = None
 DISTRO = None
 PIP_INSTALLED = False
-RedHat_ver_min_incl_max_excl = ((5,), (7,))
-Ubuntu_ver_min_incl_max_excl = ((10,), (14,))
-INITD_BASED_DISTROS = dict([('CentOS', RedHat_ver_min_incl_max_excl),
-                            ('CentOS Linux', RedHat_ver_min_incl_max_excl),
-                            ('RedHat', RedHat_ver_min_incl_max_excl),
-                            ('Ubuntu', Ubuntu_ver_min_incl_max_excl)])
-RedHat_ver_min_incl_max_excl = ((7,), (8,))
-Ubuntu_ver_min_incl_max_excl = ((14,), (16,))
-SYSTEMD_BASED_DISTROS = dict([('CentOS', RedHat_ver_min_incl_max_excl),
-                            ('CentOS Linux', RedHat_ver_min_incl_max_excl),
-                            ('RedHat', RedHat_ver_min_incl_max_excl),
-                            ('Ubuntu', Ubuntu_ver_min_incl_max_excl)])
+INITD_RedHat_ver_min_incl_max_excl = ((5,), (7,))
+INITD_Ubuntu_ver_min_incl_max_excl = ((10,), (14,))
+INITD_BASED_DISTROS = dict([('CentOS', INITD_RedHat_ver_min_incl_max_excl),
+                            ('CentOS Linux', INITD_RedHat_ver_min_incl_max_excl),
+                            ('RedHat', INITD_RedHat_ver_min_incl_max_excl),
+                            ('Ubuntu', INITD_Ubuntu_ver_min_incl_max_excl)])
+SYSTEMD_RedHat_ver_min_incl_max_excl = ((7,), (8,))
+SYSTEMD_Ubuntu_ver_min_incl_max_excl = ((14,), (16,))
+SYSTEMD_BASED_DISTROS = dict([('CentOS', SYSTEMD_RedHat_ver_min_incl_max_excl),
+                            ('CentOS Linux', SYSTEMD_RedHat_ver_min_incl_max_excl),
+                            ('RedHat', SYSTEMD_RedHat_ver_min_incl_max_excl),
+                            ('Ubuntu', SYSTEMD_Ubuntu_ver_min_incl_max_excl)])
 
 def _versiontuple(v):
     return tuple(map(int, (v.split("."))))

--- a/client/src/main/scripts/slipstream.bootstrap.py
+++ b/client/src/main/scripts/slipstream.bootstrap.py
@@ -50,7 +50,7 @@ INITD_BASED_DISTROS = dict([('CentOS', RedHat_ver_min_incl_max_excl),
                             ('RedHat', RedHat_ver_min_incl_max_excl),
                             ('Ubuntu', Ubuntu_ver_min_incl_max_excl)])
 RedHat_ver_min_incl_max_excl = ((7,), (8,))
-Ubuntu_ver_min_incl_max_excl = ((14,), (15,))
+Ubuntu_ver_min_incl_max_excl = ((14,), (16,))
 SYSTEMD_BASED_DISTROS = dict([('CentOS', RedHat_ver_min_incl_max_excl),
                             ('CentOS Linux', RedHat_ver_min_incl_max_excl),
                             ('RedHat', RedHat_ver_min_incl_max_excl),
@@ -429,13 +429,12 @@ def _create_executor_config(executor_name):
     conf['SLIPSTREAM_CONNECTOR_INSTANCE'] = os.environ.get('SLIPSTREAM_CONNECTOR_INSTANCE')
     if executor_name == 'orchestrator':
         cloud_name = os.environ['SLIPSTREAM_CLOUD']
-        pypath_prep = conf.get('PYTHONPATH', '') and (conf.get('PYTHONPATH', '') + os.pathsep) or ''
-        conf['PYTHONPATH'] =  pypath_prep + os.path.join(os.sep, 'opt', cloud_name.lower())
+        pypath_prep = conf.get('PYTHONPATH', '') and (conf.get('PYTHONPATH') + os.pathsep) or ''
+        conf['PYTHONPATH'] = pypath_prep + os.path.join(os.sep, 'opt', cloud_name.lower())
         env_matcher = re.compile('SLIPSTREAM_')
         for var, val in os.environ.items():
             if env_matcher.match(var) and var != 'SLIPSTREAM_NODE_INSTANCE_NAME':
-                #if re.search(' ', val) and not (val.startswith('"') and val.endswith('"')):
-                if re.search(' ', val) and not 'SLIPSTREAM_COOKIE':
+                if re.search(' ', val) and not (val.startswith('"') and val.endswith('"')):
                     val = '"%s"' % val
                 conf[var] = val
 

--- a/client/src/main/scripts/slipstream.bootstrap.py
+++ b/client/src/main/scripts/slipstream.bootstrap.py
@@ -455,7 +455,7 @@ def _create_executor_config(executor_name):
     conf['SLIPSTREAM_CONNECTOR_INSTANCE'] = os.environ.get('SLIPSTREAM_CONNECTOR_INSTANCE')
     if executor_name == 'orchestrator':
         cloud_name = os.environ['SLIPSTREAM_CLOUD']
-        pypath_prep = conf.get('PYTHONPATH', '') and (conf.get('PYTHONPATH') + os.pathsep) or ''
+        pypath_prep = conf.get('PYTHONPATH') + os.pathsep if conf.get('PYTHONPATH', '') else ''
         conf['PYTHONPATH'] = pypath_prep + os.path.join(os.sep, 'opt', cloud_name.lower())
         env_matcher = re.compile('SLIPSTREAM_')
         for var, val in os.environ.items():

--- a/client/src/main/scripts/slipstream.bootstrap.py
+++ b/client/src/main/scripts/slipstream.bootstrap.py
@@ -43,14 +43,30 @@ MACHINE_EXECUTOR_NAMES = ['node', 'orchestrator']
 INSTALL_CMD = None
 DISTRO = None
 PIP_INSTALLED = False
+
+"""
+Matrix showing support of different init implementations by different versions of RedHat and Ubuntu.
+
+                  systemd  | init.d   | upstart
+ RedHat <= 6         NO    |   YES    |   NO
+ RedHat >= 7        YES    |   YES*   |   NO
+ Ubuntu <= 14.04     NO    |   YES    |  YES
+ Ubuntu == 14.10    YES**  |   YES    |  YES
+ Ubuntu >= 15.x     YES    |   YES*   |   ?
+
+ *  - via redirect to systemd, provided LSB info in init.d file is correct for systemd;
+ ** - with 'systemd-sysv' package replaces upstart completely or with 'systemd' package
+      runs along with upstart;
+ ? - I don't know (konstan).
+"""
 INITD_RedHat_ver_min_incl_max_excl = ((5,), (7,))
-INITD_Ubuntu_ver_min_incl_max_excl = ((10,), (14,))
+INITD_Ubuntu_ver_min_incl_max_excl = ((10,), (15,))
 INITD_BASED_DISTROS = dict([('CentOS', INITD_RedHat_ver_min_incl_max_excl),
                             ('CentOS Linux', INITD_RedHat_ver_min_incl_max_excl),
                             ('RedHat', INITD_RedHat_ver_min_incl_max_excl),
                             ('Ubuntu', INITD_Ubuntu_ver_min_incl_max_excl)])
 SYSTEMD_RedHat_ver_min_incl_max_excl = ((7,), (8,))
-SYSTEMD_Ubuntu_ver_min_incl_max_excl = ((14,), (16,))
+SYSTEMD_Ubuntu_ver_min_incl_max_excl = ((15,), (16,))
 SYSTEMD_BASED_DISTROS = dict([('CentOS', SYSTEMD_RedHat_ver_min_incl_max_excl),
                             ('CentOS Linux', SYSTEMD_RedHat_ver_min_incl_max_excl),
                             ('RedHat', SYSTEMD_RedHat_ver_min_incl_max_excl),

--- a/client/src/test/python/TestBootstrap.py
+++ b/client/src/test/python/TestBootstrap.py
@@ -23,8 +23,8 @@ from mock import Mock
 import slipstream_bootstrap
 from slipstream_bootstrap import version_in_range
 from slipstream_bootstrap import _system_supports_initd
-from slipstream_bootstrap import RedHat_ver_min_incl_max_excl
-from slipstream_bootstrap import Ubuntu_ver_min_incl_max_excl
+from slipstream_bootstrap import INITD_RedHat_ver_min_incl_max_excl
+from slipstream_bootstrap import INITD_Ubuntu_ver_min_incl_max_excl
 
 
 class TestBootstrap(unittest.TestCase):
@@ -39,25 +39,25 @@ class TestBootstrap(unittest.TestCase):
     def test_system_supports_initd_default_ranges(self):
         slipstream_bootstrap._is_linux = Mock(return_value=True)
 
-        min_incl = RedHat_ver_min_incl_max_excl[0][0]
+        min_incl = INITD_RedHat_ver_min_incl_max_excl[0][0]
         slipstream_bootstrap._get_linux_distribution = Mock(return_value=('CentOS', str(min_incl), None))
         assert True == _system_supports_initd()
         slipstream_bootstrap._get_linux_distribution = Mock(return_value=('CentOS', str(min_incl - 0.1), None))
         assert False == _system_supports_initd()
 
-        max_excl = RedHat_ver_min_incl_max_excl[1][0]
+        max_excl = INITD_RedHat_ver_min_incl_max_excl[1][0]
         slipstream_bootstrap._get_linux_distribution = Mock(return_value=('CentOS', str(max_excl), None))
         assert False == _system_supports_initd()
         slipstream_bootstrap._get_linux_distribution = Mock(return_value=('CentOS', str(max_excl - 0.1), None))
         assert True == _system_supports_initd()
 
-        min_incl = Ubuntu_ver_min_incl_max_excl[0][0]
+        min_incl = INITD_Ubuntu_ver_min_incl_max_excl[0][0]
         slipstream_bootstrap._get_linux_distribution = Mock(return_value=('Ubuntu', str(min_incl), None))
         assert True == _system_supports_initd()
         slipstream_bootstrap._get_linux_distribution = Mock(return_value=('Ubuntu', str(min_incl - 0.1), None))
         assert False == _system_supports_initd()
 
-        max_excl = Ubuntu_ver_min_incl_max_excl[1][0]
+        max_excl = INITD_Ubuntu_ver_min_incl_max_excl[1][0]
         slipstream_bootstrap._get_linux_distribution = Mock(return_value=('Ubuntu', str(max_excl), None))
         assert False == _system_supports_initd()
         slipstream_bootstrap._get_linux_distribution = Mock(return_value=('Ubuntu', str(max_excl - 0.1), None))
@@ -71,7 +71,7 @@ class TestBootstrap(unittest.TestCase):
         slipstream_bootstrap._get_linux_distribution = Mock(return_value=('foo', '0', None))
         assert False == _system_supports_initd()
 
-        for ver in ['0', '4.0', '8']:
+        for ver in ['0', '4.0', '7']:
             slipstream_bootstrap._get_linux_distribution = Mock(return_value=('CentOS', ver, None))
             assert False == _system_supports_initd()
 

--- a/client/src/test/python/TestBootstrap.py
+++ b/client/src/test/python/TestBootstrap.py
@@ -25,6 +25,8 @@ from slipstream_bootstrap import version_in_range
 from slipstream_bootstrap import _system_supports_initd
 from slipstream_bootstrap import INITD_RedHat_ver_min_incl_max_excl
 from slipstream_bootstrap import INITD_Ubuntu_ver_min_incl_max_excl
+from slipstream_bootstrap import SYSTEMD_RedHat_ver_min_incl_max_excl
+from slipstream_bootstrap import SYSTEMD_Ubuntu_ver_min_incl_max_excl
 
 
 class TestBootstrap(unittest.TestCase):
@@ -35,6 +37,17 @@ class TestBootstrap(unittest.TestCase):
         assert False == version_in_range('1', ((0,), (1,)))
 
         assert True == version_in_range('1.2', ((1, 2), (1, 3)))
+
+        assert True == version_in_range('14.04', INITD_Ubuntu_ver_min_incl_max_excl)
+        assert True == version_in_range('14.10', INITD_Ubuntu_ver_min_incl_max_excl)
+        assert False == version_in_range('15.04', INITD_Ubuntu_ver_min_incl_max_excl)
+        assert True == version_in_range('15.04', SYSTEMD_Ubuntu_ver_min_incl_max_excl)
+
+        assert True == version_in_range('5.5', INITD_RedHat_ver_min_incl_max_excl)
+        assert True == version_in_range('6.7', INITD_RedHat_ver_min_incl_max_excl)
+        assert False == version_in_range('7', INITD_RedHat_ver_min_incl_max_excl)
+        assert True == version_in_range('7', SYSTEMD_RedHat_ver_min_incl_max_excl)
+        assert True == version_in_range('7.1', SYSTEMD_RedHat_ver_min_incl_max_excl)
 
     def test_system_supports_initd_default_ranges(self):
         slipstream_bootstrap._is_linux = Mock(return_value=True)


### PR DESCRIPTION
- Added `systemd` service configuration files for orchestrator and node machine executor services.
- Added `systemd` based configuration of the services into `slipstream.bootstrap`.
- Updated the `initd`/`systemd` distribution versions matrix and detection of the `initd`/`systemd` based distributions.
- Improvements
   - catch errors to start executor and publish abort message
   - explicitly fail during configuration of startup scripts.

Connected to #213 