### PR TITLE
Protect util.execute from None as part of command and args

### DIFF
--- a/client/src/main/python/slipstream/util.py
+++ b/client/src/main/python/slipstream/util.py
@@ -172,6 +172,12 @@ def execute(commandAndArgsList, **kwargs):
     if not isinstance(commandAndArgsList, list):
         commandAndArgsList = [commandAndArgsList]
 
+    if any(map(lambda x: x == None, commandAndArgsList)):
+        raise Exception('Wrong input. NoneType object is part of the command: %s' %
+                        commandAndArgsList)
+    else:
+        commandAndArgsList = map(str, commandAndArgsList)
+
     if is_windows():
         commandAndArgsList.insert(0, '-File')
         commandAndArgsList.insert(0, 'Bypass')

--- a/client/src/test/python/TestUtil.py
+++ b/client/src/test/python/TestUtil.py
@@ -51,6 +51,13 @@ class TestUtil(unittest.TestCase):
         finally:
             util._sanitize_env = _sanitize_env_save
 
+    def test_execute_NoneType(self):
+        try:
+            util.execute([0, 'foo', None])
+        except Exception as ex:
+            assert str(ex).startswith('Wrong input.')
+        else:
+            self.fail('Should have thrown Exception.')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Otherwise subsequent code throws exceptions which are difficult to interpret and debug.