### PR TITLE
no log produced on 0 verbosity level from user

### DIFF
--- a/client/src/main/scripts/slipstream.bootstrap.py
+++ b/client/src/main/scripts/slipstream.bootstrap.py
@@ -349,7 +349,7 @@ def _get_verbosity():
     except ValueError:
         print '[WARNING]: Verbosity level not an integer. Defaulting to 0.'
     else:
-        if verbosityLevel == 1:
+        if verbosityLevel in [0, 1]:
             verbosity = '-v'
         elif verbosityLevel == 2:
             verbosity = '-vv'

--- a/client/src/main/scripts/slipstream.bootstrap.py
+++ b/client/src/main/scripts/slipstream.bootstrap.py
@@ -430,11 +430,12 @@ def _add_executor_to_systemd(executor_name):
 
     try: os.unlink(dst)
     except: pass
-    os.symlink(src, dst)
-
-    rc, output = _get_rc_output('systemctl daemon-reload')
-    if rc != 0:
-        raise Exception('Failed registering machine executor with systemd: %s' % output)
+    shutil.copy(src, dst)
+    cmds = ['systemctl enable %s' % sname, 'systemctl daemon-reload']
+    for cmd in cmds:
+        rc, output = _get_rc_output(cmd)
+        if rc != 0:
+            raise Exception('Failed registering machine executor with systemd: %s' % output)
 
     return sname
 


### PR DESCRIPTION
- provide `-v` parameter to executor daemons even if verbosity is 0
- extra fix: need to copy systemd .service file to /etc/systemd/system for `enable` to work

Connected to #215 