### PR TITLE
Added information about the use of '--' in CLI parameters.

### DIFF
--- a/client/src/main/python/ss-abort.py
+++ b/client/src/main/python/ss-abort.py
@@ -34,9 +34,13 @@ class MainProgram(CommandBase):
         super(MainProgram, self).__init__(argv)
 
     def parse(self):
-        usage = '''usage: %prog [options] [<reason>]
+        usage = '''usage: %prog [options] [--] [<reason>]
 
-<reason>         Reason for abort.'''
+<reason>         Reason for abort.
+
+Notice:
+                 If the reason might start with a dash (-), please add the
+                 two dashes (--) before the reason to prevent possible issues.'''
 
         self.parser.usage = usage
 

--- a/client/src/main/python/ss-display.py
+++ b/client/src/main/python/ss-display.py
@@ -34,9 +34,13 @@ class MainProgram(CommandBase):
         super(MainProgram, self).__init__(argv)
 
     def parse(self):
-        usage = '''%prog [options] <value>
+        usage = '''%prog [options] [--] <value>
 
-<value>          Value to be set.'''
+<value>          Value to be set.
+
+Notice:
+                 If the value might start with a dash (-), please add the two
+                 dashes (--) before the value to prevent possible issues.'''
 
         self.parser.usage = usage
 

--- a/client/src/main/python/ss-set.py
+++ b/client/src/main/python/ss-set.py
@@ -32,13 +32,15 @@ class MainProgram(CommandBase):
         super(MainProgram, self).__init__(argv)
 
     def parse(self):
-        usage = '''%prog [options] <key> [<value>]
+        usage = '''%prog [options] [--] <key> <value>
 
-<key>            Key from which to set the value. Note that if the parameter
-                 does not exist, the run will abort.
-<value>          Value to be set.  This parameter is mandatory, unless the
-                 --decrement option is uses, in which case this parameter is
-                 ignored'''
+<key>            Key from which to set the value. This parameter is mandatory.
+                 Note that if the parameter does not exist, the run will abort.
+<value>          Value to be set. This parameter is mandatory.
+
+Notice:
+                 If the key or the value might start with a dash (-), please add
+                 the two dashes (--) before the key to prevent possible issues.'''
 
         self.parser.usage = usage
 
@@ -47,7 +49,7 @@ class MainProgram(CommandBase):
         self.options, self.args = self.parser.parse_args()
 
         if len(self.args) != 2:
-                self.usageExit('Error, two argument must be specified')
+            self.usageExit('Error, two argument must be specified')
 
         self.key = self.args[0]
         self.value = self.args[1]


### PR DESCRIPTION
If a parameter's value or a positional argument start with
a dash `-`, two dashes `--` have to be added before them.

Connected to #207