### PR TITLE
allow to download reports with ss-execute

### DIFF
--- a/client/src/main/python/slipstream/Client.py
+++ b/client/src/main/python/slipstream/Client.py
@@ -25,6 +25,7 @@ from SlipStreamHttpClient import SlipStreamHttpClient
 from exceptions.Exceptions import NotYetSetException
 from exceptions.Exceptions import TimeoutException
 from exceptions.Exceptions import ClientError
+from exceptions.Exceptions import AbortException
 
 from NodeDecorator import NodeDecorator
 import slipstream.util as util
@@ -84,6 +85,13 @@ class Client(object):
         @rtype: {str}
         """
         return self.httpClient.launchDeployment(params)
+
+    def is_run_aborted(self, run_uuid):
+        try:
+            self.httpClient.getRunState(run_uuid, ignoreAbort=False)
+            return False
+        except AbortException:
+            return True
 
     def getRunState(self, uuid, ignoreAbort=True):
         return self.httpClient.getRunState(uuid, ignoreAbort=ignoreAbort)

--- a/client/src/main/python/slipstream/resources/reports.py
+++ b/client/src/main/python/slipstream/resources/reports.py
@@ -18,6 +18,7 @@
 from __future__ import print_function
 
 import os
+import errno
 import json
 from datetime import datetime
 import pprint
@@ -83,13 +84,12 @@ class ReportsGetter(object):
     def output_fullpath(self, run_uuid, name):
         return os.path.join(self.reports_path(run_uuid), name)
 
-    def mk_download_dir(self, run_uuid):
-        _dir = self.reports_path(run_uuid)
+    @staticmethod
+    def mkdir(_dir):
         try:
             os.makedirs(_dir, mode=0755)
         except OSError as ex:
-            # Proceed further even if directory exists.
-            if ex.errno != 17:
+            if ex.errno != errno.EEXIST:
                 raise ex
         return _dir
 
@@ -135,7 +135,7 @@ class ReportsGetter(object):
             return {}
 
     def _download_reports(self, reports_list, reports_path):
-        self.mk_download_dir(reports_path)
+        self.mkdir(reports_path)
         self.info("\n::: Downloading reports to '%s'" % reports_path)
 
         for f in reports_list:

--- a/client/src/main/python/slipstream/resources/reports.py
+++ b/client/src/main/python/slipstream/resources/reports.py
@@ -106,6 +106,9 @@ class ReportsGetter(object):
 
     def get_reports(self, run_uuid, components=[], no_orch=False):
         reports_list_orig = self.list_reports(run_uuid)
+        if not reports_list_orig:
+            self.info("::: WARNING: No reports available on %s :::" % run_uuid)
+            return
 
         reports_list = self.latest_only(reports_list_orig)
         self.debug("::: Only latest reports are selected. :::", data=reports_list)

--- a/client/src/main/python/slipstream/resources/run.py
+++ b/client/src/main/python/slipstream/resources/run.py
@@ -25,7 +25,10 @@ RUN_STATES = ('Initializing',
               'Done',
               'Cancelled',
               'Aborted')
-FINAL_STATE = 'Done'
+
+FINAL_STATES = ('Done',
+                'Cancelled',
+                'Aborted')
 
 
 def run_url_to_uuid(run_url):

--- a/client/src/main/python/slipstream/resources/run.py
+++ b/client/src/main/python/slipstream/resources/run.py
@@ -1,0 +1,36 @@
+"""
+ SlipStream Client
+ =====
+ Copyright (C) 2016 SixSq Sarl (sixsq.com)
+ =====
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+RUN_STATES = ('Initializing',
+              'Provisioning',
+              'Executing',
+              'SendingReports',
+              'Ready',
+              'Finalizing',
+              'Done',
+              'Cancelled',
+              'Aborted')
+FINAL_STATE = 'Done'
+
+
+def run_url_to_uuid(run_url):
+    return run_url.rsplit('/', 1)[-1]
+
+
+def run_states_after(state):
+    return RUN_STATES[RUN_STATES.index(state) + 1:]

--- a/client/src/main/python/ss-execute.py
+++ b/client/src/main/python/ss-execute.py
@@ -365,7 +365,7 @@ class MainProgram(CommandBase):
 
         components = []
         if self.options.reports_components:
-            components = self.options.reports_components.split(',')
+            components = self.options.reports_components
         ch = ConfigHolder(options=self.options, context={'ignore': None})
         ch.context = {}
         rg = ReportsGetter(ch)

--- a/client/src/main/python/ss-execute.py
+++ b/client/src/main/python/ss-execute.py
@@ -30,7 +30,7 @@ from slipstream.exceptions.Exceptions import AbortException, TimeoutException
 from slipstream.resources.reports import ReportsGetter
 import slipstream.util as util
 from slipstream.resources.run import (run_url_to_uuid, run_states_after,
-                                      RUN_STATES, FINAL_STATE)
+                                      RUN_STATES, FINAL_STATES)
 
 RC_SUCCESS = 0
 RC_CRITICAL_DEFAULT = 1
@@ -55,7 +55,7 @@ class MainProgram(CommandBase):
     DEFAULT_SLEEP = 30  # seconds
     INITIAL_SLEEP = 10  # seconds
     INITIAL_STATE = RUN_STATES[0]
-    FINAL_STATES = [FINAL_STATE, ]
+    FINAL_STATES = FINAL_STATES
 
     def __init__(self, argv=None):
         self.moduleUri = None
@@ -120,7 +120,7 @@ class MainProgram(CommandBase):
                                help='Comma separated list of final states. ' +
                                     'Default: %s' % ', '.join(self.FINAL_STATES),
                                type='string', action="callback",
-                               callback=self._final_states_callback,
+                               callback=self._comma_separ_to_list_callback,
                                metavar='FINAL_STATES', default=self.FINAL_STATES)
 
         self.parser.add_option('--get-reports-all', dest='get_reports_all',
@@ -130,7 +130,9 @@ class MainProgram(CommandBase):
         self.parser.add_option('--get-reports', dest='reports_components',
                                help='Comma separated list of components to download reports for. '
                                     'Example: nginx,worker.1,worker.3 - will download reports for all component '
-                                    'instances of nginx and only for instances 1 and 3 of worker.', default='')
+                                    'instances of nginx and only for instances 1 and 3 of worker.',
+                               type='string', action="callback",
+                               callback=self._comma_separ_to_list_callback, default='')
 
         self.parser.add_option('--get-reports-dir', dest='output_dir',
                                help='Path to the directory to store the reports. '
@@ -139,17 +141,16 @@ class MainProgram(CommandBase):
 
         self.options, self.args = self.parser.parse_args()
 
-        if self.options.reports_components:
-            self.options.reports_components = self.options.reports_components.split(',')
-        else:
-            self.options.reports_components = []
-
         self._checkArgs()
 
         self.resourceUrl = self.args[0]
 
+        print(self.options.reports_components)
+        print('EXIT')
+        SystemExit(0)
+
     @staticmethod
-    def _final_states_callback(option, opt, value, parser):
+    def _comma_separ_to_list_callback(option, opt, value, parser):
         setattr(parser.values, option.dest, value.split(','))
 
     def _checkArgs(self):


### PR DESCRIPTION
`ss-execute` was enhanced with the following parameters to allow downloading of the reports of the deployment.

```
  --get-reports-all     Get all reports after final state is reached.
  --get-reports=REPORTS_COMPONENTS
                        Comma separated list of components to download reports
                        for. Example: nginx,worker.1,worker.3 - will download
                        reports for all component instances of nginx and only
                        for instances 1 and 3 of worker.
  --get-reports-dir=OUTPUT_DIR
                        Path to the directory to store the reports. Default:
                        <working directory>/<run-uuid>.
```

```
 ➭ ./ss-execute.py -u user -p pass examples/tutorials/service-testing/system --get-reports-all --wait 25 --get-reports-dir /tmp
Waiting 25 min for Run https://nuv.la/run/597ab745-5471-4cbc-8744-d011aabdfa82 to reach Done
[2016-57-01-15:57:16 UTC] State: Initializing
[2016-57-01-15:57:36 UTC] State: Initializing
[2016-58-01-15:58:06 UTC] State: Initializing
[2016-58-01-15:58:36 UTC] State: Provisioning
[2016-59-01-15:59:06 UTC] State: Executing
[2016-59-01-15:59:37 UTC] State: SendingReports
[2016-00-01-16:00:07 UTC] State: Finalizing
OK - State: Done. Run: https://nuv.la/run/597ab745-5471-4cbc-8744-d011aabdfa82

::: Downloading reports to '/tmp/597ab745-5471-4cbc-8744-d011aabdfa82'
... http://nuv.la/reports/597ab745-5471-4cbc-8744-d011aabdfa82/testclient.1_report_2016-06-01T155956Z.tgz
... http://nuv.la/reports/597ab745-5471-4cbc-8744-d011aabdfa82/orchestrator-exoscale-ch-gva_report_2016-06-01T160025Z.tgz
... http://nuv.la/reports/597ab745-5471-4cbc-8744-d011aabdfa82/apache.1_report_2016-06-01T155941Z.tgz
```

Connected to #280 