### PR TITLE
two unit tests to validate getter of empty and non-existent params.

### DIFF
--- a/client/src/main/python/slipstream/SlipStreamHttpClient.py
+++ b/client/src/main/python/slipstream/SlipStreamHttpClient.py
@@ -81,7 +81,7 @@ class SlipStreamHttpClient(object):
         for param in parameters:
             if param.attrib['category'] in ['General', cloud_qualifier]:
                 name = param.attrib['name']
-                userInfo[name] = param.findtext('value')
+                userInfo[name] = param.findtext('value', '')
 
         return userInfo
 

--- a/client/src/test/python/TestSlipStreamHttpClient.py
+++ b/client/src/test/python/TestSlipStreamHttpClient.py
@@ -228,6 +228,17 @@ class SlipStreamHttpClientTestCase(unittest.TestCase):
         assert None == user_info.get_cloud(param)
         assert 'default' == user_info.get_cloud(param, 'default')
 
+    def test_getUserInfo_param_wthout_value_tag(self):
+        client = SlipStreamHttpClient(ConfigHolder(config={'foo': 'bar'},
+                                                   context=self.context))
+        client._getUserContent = Mock(return_value=USER_XML)
+        user_info = client.get_user_info('StratusLab')
+
+        param = 'no.value'
+
+        assert '' == user_info.get_cloud(param)
+        assert '' == user_info.get_cloud(param, 'default')
+
     def test_server_config_dom_into_dict(self):
         conf = DomExtractor.server_config_dom_into_dict(CONFIGURATION_ETREE)
         assert conf

--- a/client/src/test/python/TestSlipStreamHttpClient.py
+++ b/client/src/test/python/TestSlipStreamHttpClient.py
@@ -202,6 +202,24 @@ class SlipStreamHttpClientTestCase(unittest.TestCase):
         assert 'on' == userInfo.get_general('On Error Run Forever')
         assert '3' == userInfo.get_general('Verbosity Level')
 
+    def test_getUserInfo_empty_param(self):
+        client = SlipStreamHttpClient(ConfigHolder(config={'foo': 'bar'},
+                                                   context=self.context))
+        client._getUserContent = Mock(return_value=USER_XML)
+        userInfo = client.get_user_info('StratusLab')
+        param = 'domain.name'
+        assert '' == userInfo.get_cloud(param)
+        assert '' == userInfo.get_cloud(param, 'default')
+
+    def test_getUserInfo_nonexistent_param(self):
+        client = SlipStreamHttpClient(ConfigHolder(config={'foo': 'bar'},
+                                                   context=self.context))
+        client._getUserContent = Mock(return_value=USER_XML)
+        userInfo = client.get_user_info('StratusLab')
+        param = 'doesnotexist'
+        assert None == userInfo.get_cloud(param)
+        assert 'default' == userInfo.get_cloud(param, 'default')
+
     def test_server_config_dom_into_dict(self):
         conf = DomExtractor.server_config_dom_into_dict(CONFIGURATION_ETREE)
         assert conf

--- a/client/src/test/python/TestSlipStreamHttpClient.py
+++ b/client/src/test/python/TestSlipStreamHttpClient.py
@@ -206,19 +206,27 @@ class SlipStreamHttpClientTestCase(unittest.TestCase):
         client = SlipStreamHttpClient(ConfigHolder(config={'foo': 'bar'},
                                                    context=self.context))
         client._getUserContent = Mock(return_value=USER_XML)
-        userInfo = client.get_user_info('StratusLab')
+        user_info = client.get_user_info('StratusLab')
+
         param = 'domain.name'
-        assert '' == userInfo.get_cloud(param)
-        assert '' == userInfo.get_cloud(param, 'default')
+
+        # Check when the value of the parameter is emply.
+        assert '' == user_info.get_cloud(param)
+        assert '' == user_info.get_cloud(param, 'default')
+
+        # Re-set value to None.
+        user_info['StratusLab.' + param] = None
+        assert None == user_info.get_cloud(param)
+        assert None == user_info.get_cloud(param, 'default')
 
     def test_getUserInfo_nonexistent_param(self):
         client = SlipStreamHttpClient(ConfigHolder(config={'foo': 'bar'},
                                                    context=self.context))
         client._getUserContent = Mock(return_value=USER_XML)
-        userInfo = client.get_user_info('StratusLab')
+        user_info = client.get_user_info('StratusLab')
         param = 'doesnotexist'
-        assert None == userInfo.get_cloud(param)
-        assert 'default' == userInfo.get_cloud(param, 'default')
+        assert None == user_info.get_cloud(param)
+        assert 'default' == user_info.get_cloud(param, 'default')
 
     def test_server_config_dom_into_dict(self):
         conf = DomExtractor.server_config_dom_into_dict(CONFIGURATION_ETREE)

--- a/client/src/test/resources/user.xml
+++ b/client/src/test/resources/user.xml
@@ -69,6 +69,13 @@
          </parameter>
       </entry>
       <entry>
+         <string>StratusLab.domain.name</string>
+         <parameter name="StratusLab.domain.name" description="Domain" category="StratusLab" mandatory="true" type="RestrictedString" readonly="false" order_="40" order="40">
+            <instructions><![CDATA[ Only useful if Identity API v3 ]]></instructions>
+            <value><![CDATA[]]></value>
+         </parameter>
+      </entry>
+      <entry>
          <string><![CDATA[StratusLab.marketplace.endpoint]]></string>
          <parameter class="com.sixsq.slipstream.persistence.UserParameter" name="StratusLab.marketplace.endpoint" description="Default marketplace endpoint" category="StratusLab" mandatory="true" type="String" readonly="false">
             <value><![CDATA[http://marketplace.stratuslab.eu]]></value>

--- a/client/src/test/resources/user.xml
+++ b/client/src/test/resources/user.xml
@@ -76,6 +76,11 @@
          </parameter>
       </entry>
       <entry>
+         <string>StratusLab.no.value</string>
+         <parameter name="StratusLab.no.value" description="No value" category="StratusLab" mandatory="true" type="RestrictedString" readonly="false" order_="40" order="40">
+         </parameter>
+      </entry>
+      <entry>
          <string><![CDATA[StratusLab.marketplace.endpoint]]></string>
          <parameter class="com.sixsq.slipstream.persistence.UserParameter" name="StratusLab.marketplace.endpoint" description="Default marketplace endpoint" category="StratusLab" mandatory="true" type="String" readonly="false">
             <value><![CDATA[http://marketplace.stratuslab.eu]]></value>


### PR DESCRIPTION
@schaubl I see no other way for the failure we saw with the empty user param on ultimum (see stacktrace) but either

* 'domain.name' gets re-set with `None` somewhere in the OpenStack connector
* the implementation of `etree` lib on Orch returns `None` here https://github.com/slipstream/SlipStreamClient/blob/master/client/src/main/python/slipstream/SlipStreamHttpClient.py#L84 `userInfo[name] = param.findtext('value')`

```
: 2016-06-20T13:57:07Z : 
ERROR: Error executing node, with detail: 'NoneType' object has no attribute 'strip'
Traceback (most recent call last):
  File "/opt/slipstream/client/lib/slipstream/executors/MachineExecutor.py", line 106, in _execute_state
    getattr(self, method_name)()
  File "/opt/slipstream/client/lib/slipstream/util.py", line 112, in overrided_func
    return func(self, *args, **kwargs)
  File "/opt/slipstream/client/lib/slipstream/executors/orchestrator/OrchestratorDeploymentExecutor.py", line 40, in onProvisioning
    self._start_instances()
  File "/opt/slipstream/client/lib/slipstream/executors/orchestrator/OrchestratorDeploymentExecutor.py", line 88, in _start_instances
    self._run_instances_action(self.wrapper.start_node_instances, 'starting')
  File "/opt/slipstream/client/lib/slipstream/executors/orchestrator/OrchestratorDeploymentExecutor.py", line 110, in _run_instances_action
    action()
  File "/opt/slipstream/client/lib/slipstream/wrappers/CloudWrapper.py", line 81, in start_node_instances
    self._get_user_info(self._get_cloud_service_name()), nodes_instances)
  File "/opt/slipstream/client/lib/slipstream/wrappers/CloudWrapper.py", line 103, in _start_nodes_and_clients
    self._cloud_client.start_nodes_and_clients(user_info, nodes_instances)
  File "/opt/slipstream/client/lib/slipstream/cloudconnectors/BaseCloudConnector.py", line 379, in start_nodes_and_clients
    self._initialization(user_info, **init_extra_kwargs)
  File "/opt/slipstream/client/lib/slipstream/util.py", line 112, in overrided_func
    return func(self, *args, **kwargs)
  File "/opt/openstack/slipstream_openstack/OpenStackClientCloud.py", line 77, in _initialization
    self._thread_local.driver = self._get_driver(user_info)
  File "/opt/openstack/slipstream_openstack/OpenStackClientCloud.py", line 254, in _get_driver
    domain = user_info.get_cloud('domain.name', 'default').strip()
AttributeError: 'NoneType' object has no attribute 'strip'
```

Please check and comment.  Thanks.

