### PR TITLE
ss-get-all CLI

### DIFF
--- a/client/src/main/python/slipstream/Client.py
+++ b/client/src/main/python/slipstream/Client.py
@@ -260,7 +260,7 @@ class Client(object):
         POOL_MAX = 9
         params = self._get_params_list(compname, key)
         nparams = len(params)
-        pool_size = POOL_MAX if nparams > POOL_MAX else nparams
+        pool_size = min(POOL_MAX, nparams)
         self._printDetail("Get %s RTP instances with pool size: %s" %
                           (nparams,  pool_size))
         pool = ThreadPool(pool_size)

--- a/client/src/main/python/ss-get-all.bat
+++ b/client/src/main/python/ss-get-all.bat
@@ -1,0 +1,2 @@
+@echo off
+python "%~dp0%~n0" %*

--- a/client/src/main/python/ss-get-all.py
+++ b/client/src/main/python/ss-get-all.py
@@ -61,7 +61,7 @@ class MainProgram(CommandBase):
                                help='expected value; check if all components '
                                'set the parameter to the expected value; exits '
                                'with 1 if parameter not equal to the value on '
-                               'any of the of the components', metavar='VALUE')
+                               'any of the components', metavar='VALUE')
 
         self.options, self.args = self.parser.parse_args()
 

--- a/client/src/main/python/ss-get-all.py
+++ b/client/src/main/python/ss-get-all.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+"""
+ SlipStream Client
+ =====
+ Copyright (C) 2014 SixSq Sarl (sixsq.com)
+ =====
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+from __future__ import print_function
+
+import sys
+
+from slipstream.Client import Client
+from slipstream.ConfigHolder import ConfigHolder
+from slipstream.command.CommandBase import CommandBase
+
+
+class MainProgram(CommandBase):
+    """
+    A command-line program to get a runtime parameter value from a run,
+    blocking (by default) if not set.
+    """
+
+    def __init__(self, argv=None):
+        super(MainProgram, self).__init__(argv)
+        self.compname = None
+        self.key = None
+
+    def parse(self):
+        usage = """usage: %prog [options] <component> <key>
+
+<component> Name of the component.
+<key>       Key (non-qualified runtime parameter) to retrieve the value from
+"""
+
+        self.parser.usage = usage
+
+        self.parser.add_option('--timeout', dest='timeout',
+                               help='timeout in seconds for blocking call',
+                               metavar='SECONDS',
+                               default=60, type='int')
+
+        self.addIgnoreAbortOption()
+
+        self.parser.add_option('--noblock', dest='noBlock',
+                               help='return immediately even if the parameter '
+                                    'has no value',
+                               default=False, action='store_true')
+
+        self.options, self.args = self.parser.parse_args()
+
+        self._check_args()
+        self.compname = self.args[0]
+        self.key = self.args[1]
+
+    def _check_args(self):
+        if len(self.args) < 1:
+            self.parser.error('Missing component name and key')
+        if len(self.args) < 2:
+            self.parser.error('Missing key')
+        if len(self.args) > 2:
+            self.usageExitTooManyArguments()
+
+    def _get_client(self):
+        configHolder = ConfigHolder(self.options)
+        return Client(configHolder)
+
+    def doWork(self):
+        client = self._get_client()
+        params = client.get_rtp_all(self.compname, self.key)
+        for k, v in params:
+            print(k, v)
+
+
+if __name__ == "__main__":
+    try:
+        MainProgram()
+    except KeyboardInterrupt:
+        print('\n\nExecution interrupted by the user... goodbye!')
+        sys.exit(-1)

--- a/client/src/test/python/TestClient.py
+++ b/client/src/test/python/TestClient.py
@@ -94,7 +94,7 @@ class TestClient(unittest.TestCase):
         assert isinstance(params, list)
         assert len(params) == nrtps
         for _, v in params:
-            assert v == ''
+            assert '' == v
 
     def test_get_rtp_all_somenotset_notimeout(self):
 


### PR DESCRIPTION
Useful when checking component's readiness. E.g.:

```
ss-get-all my_cluster ready --value true --timeout 600
```

```
$ ss-get-all -h
Usage: usage: ss-get-all.py [options] <component> <key>

<component> Name of the component.
<key>       Key (non-qualified runtime parameter) to retrieve the value from


Options:
  -h, --help         show this help message and exit
  -v, --verbose      verbose level. Add more to get more details.
  --timeout=SECONDS  timeout in seconds for blocking call
  --ignore-abort     by default, if the run abort flag is set, any
                     call will return with an error. With this option values
                     can be queried even if the abort flag is raised
  --noblock          return immediately even if the parameter has no value
  --value=VALUE      expected value; check if all components set the parameter
                     to the expected value; exits with 1 if parameter not
                     equal to the value on any of the of the components
$
```

```
$ ss-get testclient.1:hostname
foo
$ ss-get testclient.2:hostname
foo
$ ss-get testclient.3:hostname
foo
$ ./ss-get-all.py testclient hostname
testclient.1:hostname foo
testclient.2:hostname foo
testclient.3:hostname foo
$ # Set to unexpected value and call with --value
$ ss-set testclient.2:hostname abc
$ ./ss-get-all.py testclient hostname --value foo
RTP value on some components not equal to the expected value: foo
testclient.1:hostname foo
testclient.2:hostname abc
testclient.3:hostname foo
$ echo $?
1
$ # Unset parameter and call with --value and --timeout
$ ss-set testclient.2:hostname ''
$ ./ss-get-all.py testclient hostname --value foo --timeout 5
Waiting for testclient.2:hostname
Exceeded timeout limit of 5 waiting for key 'testclient.2:hostname' to be set
RTP value on some components not equal to the expected value: foo
testclient.1:hostname foo
testclient.2:hostname
testclient.3:hostname foo
$ echo $?
1
$
```

Connected to #325 