### PR TITLE
Fix bad usage of _vm_get_id in in _get_failed_instances_on_iaas and add method

### DIFF
--- a/client/src/main/python/slipstream/cloudconnectors/BaseCloudConnector.py
+++ b/client/src/main/python/slipstream/cloudconnectors/BaseCloudConnector.py
@@ -126,6 +126,11 @@ class BaseCloudConnector(object):
         Returns: one IP - Public or Private."""
         pass
 
+    def _vm_get_id_from_list_instances(self, vm_instance):
+        """Retrieve an ID from the vm_instance object returned by list_instances().
+        Returns: one ID."""
+        pass
+
     def _vm_get_cpu(self, vm_instance):
         """Retrieve the number of CPU of the VM from the vm_instance object returned by list_instances().
         Returns: the number of CPU of VM"""

--- a/client/src/main/python/slipstream/wrappers/CloudWrapper.py
+++ b/client/src/main/python/slipstream/wrappers/CloudWrapper.py
@@ -274,7 +274,7 @@ class CloudWrapper(BaseWrapper):
         vms = self._cloud_client.list_instances()
         failed_instances = {}
         for vm in vms:
-            vm_id = self._cloud_client._vm_get_id(vm)
+            vm_id = self._cloud_client._vm_get_id_from_list_instances(vm)
             if (vm_id in vm_ids) and self._cloud_client._has_vm_failed(vm):
                 instance = vm_id_to_instance[vm_id]
                 failed_instances.setdefault(instance.get_node_name(), []).append(instance)


### PR DESCRIPTION
Connected to SixSq/tasklist#1369
Connected to slipstream/SlipStreamConnectors#173