### PR TITLE
 substitute usage of machine cookie with api key/secret

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -20,6 +20,7 @@
       <classifier>bundle</classifier>
       <version>${project.version}</version>
     </dependency>
+    <!--
     <dependency>
       <groupId>com.sixsq.slipstream</groupId>
       <artifactId>Libcloud-SixSq-zip</artifactId>
@@ -27,6 +28,7 @@
       <classifier>bundle</classifier>
       <version>${project.version}</version>
     </dependency>
+    -->
   </dependencies>
 
   <profiles>
@@ -53,7 +55,7 @@
                 <configuration>
                   <executable>nosetests</executable>
                   <environmentVariables>
-                    <PYTHONPATH>./target/test/python/:./target/main/python/:./src/external/mock/:./src/external/:./src/main/scripts/:./target/dependencies</PYTHONPATH>
+                    <PYTHONPATH>./target/test/python/:./target/main/python/:./src/external/:./src/main/scripts/:./target/dependencies:./target/dependencies/slipstream-api/src</PYTHONPATH>
                   </environmentVariables>
                   <arguments>
                     <argument>-v</argument>

--- a/client/src/main/python/slipstream/HttpClient.py
+++ b/client/src/main/python/slipstream/HttpClient.py
@@ -16,21 +16,17 @@
  limitations under the License.
 """
 
-import os
+from __future__ import print_function
+
 import time
 import httplib
 import requests
-import re
 import socket
-import stat
 from random import random
 from threading import Lock
 from urlparse import urlparse
-from cookielib import CookieJar
-from requests import Request
 from requests.exceptions import RequestException
-from requests.cookies import MockResponse, MockRequest, RequestsCookieJar
-from six.moves.http_cookiejar import MozillaCookieJar
+from requests.cookies import RequestsCookieJar
 
 try:
     from requests.packages.urllib3.exceptions import HTTPError
@@ -39,11 +35,11 @@ except:
 
 import slipstream.exceptions.Exceptions as Exceptions
 import slipstream.util as util
+from slipstream.api.api import Api
 
 etree = util.importETree()
 
 DEFAULT_SS_COOKIE_NAME = 'com.sixsq.slipstream.cookie'
-MACHINE_COOKIE_KEY = 'com.sixsq.isMachine'
 
 
 def get_cookie(cookie_jar, domain, path=None, name=DEFAULT_SS_COOKIE_NAME):
@@ -69,53 +65,6 @@ def get_cookie(cookie_jar, domain, path=None, name=DEFAULT_SS_COOKIE_NAME):
         return cookie
     else:
         return '%s=%s' % (name, cookie)
-
-
-class SessionStore(requests.Session):
-    """Session with extended MozillaCookieJar file-based store.
-    """
-
-    def __init__(self, cookie_file=None):
-        super(SessionStore, self).__init__()
-        if cookie_file is None:
-            cookie_file = util.DEFAULT_COOKIE_FILE
-        cookie_dir = os.path.dirname(cookie_file)
-        self.cookies = MozillaCookieJar(cookie_file)
-        if not os.path.isdir(cookie_dir):
-            os.mkdir(cookie_dir, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
-        if os.path.isfile(cookie_file):
-            self.cookies.load(ignore_discard=True)
-            self.cookies.clear_expired_cookies()
-
-    def request(self, *args, **kwargs):
-        response = super(SessionStore, self).request(*args, **kwargs)
-        if not self.verify and response.cookies:
-            self._unsecure_cookie(args[1], response)
-        if 'Set-Cookie' in response.headers:
-            self.cookies.save(ignore_discard=True)
-        return response
-
-    def _unsecure_cookie(self, url_str, response):
-        url = urlparse(url_str)
-        if url.scheme.lower() == 'http':
-            for cookie in response.cookies:
-                cookie.secure = False
-                self.cookies.set_cookie_if_ok(cookie,
-                                              MockRequest(response.request))
-
-    def clear(self, domain, path=None, name=None):
-        try:
-            self.cookies.clear(domain, path, name)
-            self.cookies.save()
-        except KeyError as ex:
-            util.printError("Failed to clear local cookie: %s" % ex)
-
-    def set_cookies(self, cookies=[]):
-        for c in cookies:
-            self.cookies.set_cookie(c)
-
-    def get_cookie(self, domain, path=None, name=DEFAULT_SS_COOKIE_NAME):
-        return get_cookie(self.cookies, domain, path, name)
 
 
 # Client Error
@@ -156,8 +105,7 @@ def disable_urllib3_warnings():
 
 class HttpClient(object):
 
-    def __init__(self, cookie=None, configHolder=None):
-        self.cookie = cookie
+    def __init__(self, configHolder=None):
         self.host_cert_verify = False
         self.verboseLevel = util.VERBOSE_LEVEL_NORMAL
         self.cookie_filename = util.DEFAULT_COOKIE_FILE
@@ -218,7 +166,7 @@ class HttpClient(object):
             else:
                 detail = _extract_detail(resp.text)
                 detail = detail and detail or (
-                    "%s (%d)" % (resp.reason, resp.status_code))
+                        "%s (%d)" % (resp.reason, resp.status_code))
                 msg = "Failed calling method %s on url %s, with reason: %s" % (
                     method, url, detail)
                 clientEx = Exceptions.ClientError(msg)
@@ -332,45 +280,18 @@ class HttpClient(object):
             self.init_session(url)
         self.session.clear(_url.netloc, _url.path, DEFAULT_SS_COOKIE_NAME)
 
-    @staticmethod
-    def _is_machine_cookie(cookie_str):
-        """Expected structure of the cookie string:
-        com.sixsq.slipstream.cookie=k1=val1&k2=val2; Path=<URI>
-        """
-        if re.search('%s=true' % MACHINE_COOKIE_KEY, cookie_str):
-            return True
-        return False
-
-    def _url_for_cookie(self, cookie_str, url):
-        """Machine cookie allows access to /.
-        """
-        if self._is_machine_cookie(cookie_str):
-            _url = urlparse(url)
-            return '%s://%s/' % (_url.scheme, _url.netloc)
-        else:
-            return url
-
-    def _cookie_from_str(self, url, cookie_str):
-        from StringIO import StringIO
-        data = "Set-Cookie: %s" % cookie_str
-        headers = httplib.HTTPMessage(StringIO(data))
-        resp = MockResponse(headers)
-        req = MockRequest(Request(method='GET',
-                                  url=self._url_for_cookie(cookie_str, url)))
-        jar = CookieJar()
-        return jar.make_cookies(resp, req)
-
-    def _set_oldstyle_cookie_on_session(self, url):
-        if self.cookie:
-            cookies = self._cookie_from_str(url, self.cookie)
-            self.session.set_cookies(cookies)
-            self.cookie = None
-
     def init_session(self, url):
         if self.session is None:
-            self.session = SessionStore(cookie_file=self.cookie_filename)
-            # TODO: remove when old cookie from ConfigHolder is gone.
-            self._set_oldstyle_cookie_on_session(url)
+            url_parts = urlparse(url)
+            endpoint = '%s://%s' % url_parts[:2]
+            api = Api(endpoint=endpoint, cookie_file=self.cookie_filename, reauthenticate=True)
+            if hasattr(self, 'username') and hasattr(self, 'password'):
+                api.login_internal(self.username, self.password)
+            elif hasattr(self, 'api_key') and hasattr(self, 'api_secret'):
+                api.login_apikey(self.api_key, self.api_secret)
+            else:
+                raise Exception('Unable to login to %s. No credentials defined.' % endpoint)
+            self.session = api.session
 
     def _log_normal(self, message):
         util.printDetail(message, self.verboseLevel,

--- a/client/src/main/python/slipstream/HttpClient.py
+++ b/client/src/main/python/slipstream/HttpClient.py
@@ -284,13 +284,13 @@ class HttpClient(object):
         if self.session is None:
             url_parts = urlparse(url)
             endpoint = '%s://%s' % url_parts[:2]
-            api = Api(endpoint=endpoint, cookie_file=self.cookie_filename, reauthenticate=True)
+            login_creds = {}
             if hasattr(self, 'username') and hasattr(self, 'password'):
-                api.login_internal(self.username, self.password)
+                login_creds = {'username': self.username, 'password': self.password}
             elif hasattr(self, 'api_key') and hasattr(self, 'api_secret'):
-                api.login_apikey(self.api_key, self.api_secret)
-            else:
-                raise Exception('Unable to login to %s. No credentials defined.' % endpoint)
+                login_creds = {'key': self.api_key, 'secret': self.api_secret}
+            api = Api(endpoint=endpoint, cookie_file=self.cookie_filename, reauthenticate=True,
+                      login_creds=login_creds)
             self.session = api.session
 
     def _log_normal(self, message):

--- a/client/src/main/python/slipstream/SlipStreamHttpClient.py
+++ b/client/src/main/python/slipstream/SlipStreamHttpClient.py
@@ -59,8 +59,6 @@ class SlipStreamHttpClient(object):
 
         self.authnServiceUrl = self.serviceurl + '/api/session'
 
-        self.externalObjectUrl = self.serviceurl + '/api/external-object'
-
         self.runReportEndpoint = '%s/reports/%s' % (self.serviceurl,
                                                     self.diid)
 
@@ -185,22 +183,7 @@ class SlipStreamHttpClient(object):
             NodeDecorator.globalNamespacePrefix + NodeDecorator.ABORT_KEY, message)
 
     def sendReport(self, report):
-        resource_id = self._createExternalObjectReport()
-        upload_url = self._generateUploadUrlExternalObjectReport(resource_id)
-        self._uploadReport(upload_url, report)
-
-    def _createExternalObjectReport(self):
-        # FIXME !!!! ss is the python api client
-        resp = ss.cimi_add('externalObjects',
-                           {'externalObjectTemplate': {'href': 'external-object-template/report',
-                                                       'runUUID': self.diid,
-                                                       'component': self.node_instance_name}})
-        return resp.json['resource-id']
-
-    def _generateUploadUrlExternalObjectReport(self, resource_id):
-        # FIXME !!!! ss is the python api client
-        resp = ss.cimi_operation(resource_id, "http://sixsq.com/slipstream/1/action/upload", {'ttl': 5})
-        return resp.json['uri']
+        self._uploadReport(self.runReportEndpoint, report)
 
     def _uploadReport(self, url, report):
         print('Uploading report to: %s' % url)

--- a/client/src/main/python/slipstream/__init__.py
+++ b/client/src/main/python/slipstream/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/client/src/setup.py
+++ b/client/src/setup.py
@@ -78,5 +78,6 @@ setup(
     classifiers=CLASSIFIERS,
     packages=packages,
     package_dir={'slipstream': 'lib/slipstream'},
-    requires=['httplib2']
+    requires=['httplib2'],
+    namespace_packages=['slipstream']
 )

--- a/pypi/src/main/python/setup.py
+++ b/pypi/src/main/python/setup.py
@@ -42,6 +42,7 @@ setup(
     license='Apache License, Version 2.0',
     platforms='Any',
     url='http://sixsq.com',
+    namespace_packages=['slipstream'],
     install_requires=[
         'requests',
         'six'],


### PR DESCRIPTION
- removes the usage of machine cookie
- adds slipstream.api.api.Api
- uses slipstream.api.api.Api for login and cookie management

@0xbase12 NB! Libcloud-SixSq-zip dependency is commented out as it didn't work for me with it.  Need to check this

Relies on https://github.com/slipstream/SlipStreamPythonAPI/pull/66.  Please merge it first.

Connected to #380 